### PR TITLE
fix(sage-llm): Strict reasoning_effort compatibility for google_genai

### DIFF
--- a/packages/sage-llm/src/sage_llm/providers/google_genai.py
+++ b/packages/sage-llm/src/sage_llm/providers/google_genai.py
@@ -434,8 +434,22 @@ def _build_config(
 
     # Thinking
     if reasoning_effort is not None:
-        budget = reasoning_effort if isinstance(reasoning_effort, int) else 8192
-        cfg["thinking_config"] = types.ThinkingConfig(thinking_budget=budget, include_thoughts=True)
+        if isinstance(reasoning_effort, int):
+            # Integer effort for Gemini <3
+            cfg["thinking_config"] = types.ThinkingConfig(
+                thinking_budget=reasoning_effort, include_thoughts=True
+            )
+        else:
+            # String effort for Gemini 3+
+            level = types.ThinkingLevel(reasoning_effort)
+            # Google's enums allow arbitrary values, check that this matched the known values.
+            if level not in types.ThinkingLevel:
+                raise ValueError(
+                    f"Unsupported string reasoning_effort for Google: {reasoning_effort}"
+                )
+            cfg["thinking_config"] = types.ThinkingConfig(
+                thinking_level=level, include_thoughts=True
+            )
 
     # Structured output
     if response_format is not None:

--- a/packages/sage-llm/tests/providers/test_google.py
+++ b/packages/sage-llm/tests/providers/test_google.py
@@ -313,7 +313,8 @@ class TestBuildConfig:
         assert config.temperature == 0.5
         assert config.max_output_tokens == 1000
 
-    def test_thinking_config(self):
+    def test_thinking_config_int_budget(self):
+        """Integer reasoning_effort → thinking_budget (Gemini <3)."""
         config = _build_config(
             system_instruction=None,
             temperature=None,
@@ -327,6 +328,56 @@ class TestBuildConfig:
         )
         assert config.thinking_config is not None
         assert config.thinking_config.thinking_budget == 4000
+        assert config.thinking_config.thinking_level is None
+        assert config.thinking_config.include_thoughts is True
+
+    def test_thinking_config_string_level(self):
+        """String reasoning_effort → thinking_level (Gemini 3+)."""
+        config = _build_config(
+            system_instruction=None,
+            temperature=None,
+            max_tokens=None,
+            top_p=None,
+            stop=None,
+            tools=None,
+            tool_choice=None,
+            reasoning_effort="LOW",
+            response_format=None,
+        )
+        assert config.thinking_config is not None
+        assert config.thinking_config.thinking_level == types.ThinkingLevel.LOW
+        assert config.thinking_config.thinking_budget is None
+        assert config.thinking_config.include_thoughts is True
+
+    def test_thinking_config_invalid_string_raises(self):
+        """Unknown string effort is rejected with ValueError."""
+        with pytest.raises(ValueError, match="Unsupported string reasoning_effort"):
+            _build_config(
+                system_instruction=None,
+                temperature=None,
+                max_tokens=None,
+                top_p=None,
+                stop=None,
+                tools=None,
+                tool_choice=None,
+                reasoning_effort="not-a-level",
+                response_format=None,
+            )
+
+    def test_thinking_config_omitted_when_none(self):
+        """No reasoning_effort → no thinking_config on the request."""
+        config = _build_config(
+            system_instruction=None,
+            temperature=None,
+            max_tokens=None,
+            top_p=None,
+            stop=None,
+            tools=None,
+            tool_choice=None,
+            reasoning_effort=None,
+            response_format=None,
+        )
+        assert config.thinking_config is None
 
     def test_response_format(self):
         class MyModel(BaseModel):


### PR DESCRIPTION
Instead of silently setting unrecognized reasoning_efforts to a budget of 8192, be strict about types and support Gemini 3+ string-based ThinkingLevel.

Fixes: https://github.com/microsoft/sage/issues/535

To test:

```bash
uv run pytest packages/sage-llm/tests/providers/test_google.py::TestBuildConfig

sagebench experiment \
  experiments/smoke \
  -k calendar --restart-exec \
  --set model=gemini-3-flash-preview --set reasoning_effort=low \
  --and --set model=gemini-3-flash-preview --set reasoning_effort=8192
```

---

**PR Checklist (do not remove):**

- [x] I linked this PR to an issue
- [x] I included code instructions on how to test
