### PR TITLE
Don't treat max rounds exceeded as error

### DIFF
--- a/packages/sage-benchmark/sage_benchmark/benchmarks/calendar_scheduling/executor.py
+++ b/packages/sage-benchmark/sage_benchmark/benchmarks/calendar_scheduling/executor.py
@@ -364,8 +364,6 @@ async def execute_task(
             break
 
     max_rounds_reached = rounds_completed >= max_rounds and not conversation_ended_naturally
-    if max_rounds_reached:
-        exec_error = f"Max rounds reached ({max_rounds}) without natural conversation end"
 
     # Log completion (don't call on_task_complete here - that's done after eval)
     benchmark_logger.debug(

--- a/packages/sage-benchmark/sage_benchmark/benchmarks/marketplace/executor.py
+++ b/packages/sage-benchmark/sage_benchmark/benchmarks/marketplace/executor.py
@@ -242,10 +242,6 @@ async def execute_task(
         env.state.outcome.ended_by = "max_rounds"
         env.state.outcome.end_reason = "Reached max rounds without agreement."
 
-    error = None
-    if env.state.outcome.ended_by == "max_rounds":
-        error = f"Max rounds reached ({max_rounds}) without agreement"
-
     return MarketplaceExecutionResult(
         task=task,
         outcome=env.state.outcome,
@@ -255,5 +251,4 @@ async def execute_task(
         invalid_actions=invalid_actions,
         buyer_context=buyer_agent.messages,
         seller_context=seller_agent.messages,
-        error=error,
     )

--- a/packages/sage-benchmark/sage_benchmark/benchmarks/marketplace/executor.py
+++ b/packages/sage-benchmark/sage_benchmark/benchmarks/marketplace/executor.py
@@ -202,41 +202,49 @@ async def execute_task(
     action_trace = []
     invalid_actions = 0
 
-    for round_num in range(1, max_rounds + 1):
-        env.state.current_round = round_num
-        benchmark_logger.info("Task %d - Round %d", task.id, round_num)
-        for resources, agent in [(seller_resources, seller_agent), (buyer_resources, buyer_agent)]:
+    error: str | None = None
+    try:
+        for round_num in range(1, max_rounds + 1):
+            env.state.current_round = round_num
+            benchmark_logger.info("Task %d - Round %d", task.id, round_num)
+            for resources, agent in [
+                (seller_resources, seller_agent),
+                (buyer_resources, buyer_agent),
+            ]:
+                if env.state.outcome.end_reason is not None:
+                    break
+
+                # Round 1 seller turn: force initial offer at listed price
+                if (
+                    round_num == 1
+                    and task.product.listed_price is not None
+                    and isinstance(agent, SellerAgent)
+                ):
+                    await _force_initial_seller_offer(agent, resources, task, action_trace)
+                    continue
+
+                unread_updates = resources.get_unread_updates()
+                agent.add_new_messages(unread_updates)
+                turn_invalid_actions, agent_ended = await _run_agent_turn(
+                    agent, resources, max_steps_per_turn, action_trace, benchmark_logger
+                )
+                invalid_actions += turn_invalid_actions
+
+                # If generation failed, _run_agent_turn returns ended=True but environment isn't ended yet.
+                if (
+                    agent_ended
+                    and not env.state.outcome.deal_reached
+                    and env.state.outcome.end_reason is None
+                ):
+                    env.state.outcome.ended_by = resources.role
+                    env.state.outcome.end_reason = "Agent generation error."
+                    break
+
             if env.state.outcome.end_reason is not None:
                 break
-
-            # Round 1 seller turn: force initial offer at listed price
-            if (
-                round_num == 1
-                and task.product.listed_price is not None
-                and isinstance(agent, SellerAgent)
-            ):
-                await _force_initial_seller_offer(agent, resources, task, action_trace)
-                continue
-
-            unread_updates = resources.get_unread_updates()
-            agent.add_new_messages(unread_updates)
-            turn_invalid_actions, agent_ended = await _run_agent_turn(
-                agent, resources, max_steps_per_turn, action_trace, benchmark_logger
-            )
-            invalid_actions += turn_invalid_actions
-
-            # If generation failed, _run_agent_turn returns ended=True but environment isn't ended yet.
-            if (
-                agent_ended
-                and not env.state.outcome.deal_reached
-                and env.state.outcome.end_reason is None
-            ):
-                env.state.outcome.ended_by = resources.role
-                env.state.outcome.end_reason = "Agent generation error."
-                break
-
-        if env.state.outcome.end_reason is not None:
-            break
+    except Exception as ex:
+        logger.exception("Error during execution.")
+        error = str(ex)
 
     if not env.state.outcome.deal_reached and env.state.outcome.end_reason is None:
         env.state.outcome.ended_by = "max_rounds"
@@ -251,4 +259,5 @@ async def execute_task(
         invalid_actions=invalid_actions,
         buyer_context=buyer_agent.messages,
         seller_context=seller_agent.messages,
+        error=error,
     )


### PR DESCRIPTION
Resolves: https://github.com/microsoft/sage/issues/531

Instead of treating max_rounds exceeded as an error, treat it as a succeeded task so that it is included in aggregate metrics.

To test:

```bash
sagebench experiment \
  experiments/smoke \
  --restart-exec \
  --set model=azure_pool/gpt-4.1 --set limit=3 --set max_rounds=1
```

Then check that all error fields are none (requires `jq`):
```bash
for file in $(echo outputs/smoke,model=azure_pool_gpt-4.1,max_rounds=1/**/results.json); do \
jq -e '[.results[] | select(.execution.error != null)] | length == 0' $file; \
done
```

Which should print:
```
true
true
```

---

**PR Checklist (do not remove):**

- [x] I linked this PR to an issue
- [x] I included code instructions on how to test
