### PR TITLE
The organizer of a meeting should default to ACCEPTED

### DIFF
--- a/packages/sage-data-gen/sage_data_gen/calendar_scheduling/generate_tasks.py
+++ b/packages/sage-data-gen/sage_data_gen/calendar_scheduling/generate_tasks.py
@@ -654,9 +654,7 @@ async def generate_task_for_archetype(
                     start_time="09:00",  # placeholder, set in assembly
                     end_time="10:00",  # placeholder, set in assembly
                     attendees=[
-                        Attendee(
-                            email=requestor_emp.email, status=AttendeeStatus.ACCEPTED
-                        ),
+                        Attendee(email=requestor_emp.email, status=AttendeeStatus.ACCEPTED),
                         Attendee(email=employee.email, status=AttendeeStatus.AWAITING_RESPONSE),
                     ],
                 ),

--- a/packages/sage-data-gen/sage_data_gen/calendar_scheduling/generate_tasks.py
+++ b/packages/sage-data-gen/sage_data_gen/calendar_scheduling/generate_tasks.py
@@ -655,7 +655,7 @@ async def generate_task_for_archetype(
                     end_time="10:00",  # placeholder, set in assembly
                     attendees=[
                         Attendee(
-                            email=requestor_emp.email, status=AttendeeStatus.AWAITING_RESPONSE
+                            email=requestor_emp.email, status=AttendeeStatus.ACCEPTED
                         ),
                         Attendee(email=employee.email, status=AttendeeStatus.AWAITING_RESPONSE),
                     ],


### PR DESCRIPTION
I noticed that the requestor appears as "AWAITING_RESPONSE" on their own initial meeting request. They should be "ACCEPTED"

---

**PR Checklist (do not remove):**

- [ ] I linked this PR to an issue
- [ ] I included code instructions on how to test
