### PR TITLE
refactor(srbench-llm): separate input vs output message types

### DIFF
--- a/packages/privacy-judge/src/privacy_judge/leakage/judge.py
+++ b/packages/privacy-judge/src/privacy_judge/leakage/judge.py
@@ -8,9 +8,8 @@ from typing import TYPE_CHECKING
 
 from openai.types.chat.chat_completion_message_tool_call import (
     ChatCompletionMessageToolCall,
-    Function,
 )
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchMessage
+from srbench_llm import SRBenchInputMessage
 
 from .models import LeakageExample, LeakageJudgment
 from .prompts import BASE_SYSTEM_PROMPT
@@ -71,13 +70,13 @@ class LeakageJudge:
         """
         return BASE_SYSTEM_PROMPT.format(domain=self._domain)
 
-    def _build_example_messages(self) -> list[SRBenchMessage]:
+    def _build_example_messages(self) -> list[SRBenchInputMessage]:
         """Build few-shot example messages as User/ToolCall/ToolResult sequences.
 
         Returns:
             List of messages representing few-shot examples for the LLM.
         """
-        messages: list[SRBenchMessage] = []
+        messages: list[SRBenchInputMessage] = []
 
         for i, example in enumerate(self._examples):
             # User content with secret + input
@@ -91,25 +90,25 @@ class LeakageJudge:
             # Assistant tool call
             tool_call_id = f"example_{i}"
             messages.append(
-                SRBenchChatCompletionMessage(
-                    role="assistant",
-                    tool_calls=[
-                        ChatCompletionMessageToolCall(
-                            id=tool_call_id,
-                            type="function",
-                            function=Function(
-                                name=ReportLeakage.__name__,
-                                arguments=json.dumps(
+                {
+                    "role": "assistant",
+                    "tool_calls": [
+                        {
+                            "id": tool_call_id,
+                            "type": "function",
+                            "function": {
+                                "name": ReportLeakage.__name__,
+                                "arguments": json.dumps(
                                     {
                                         "reasoning": example.reasoning,
                                         "leaked": example.leaked,
                                         "evidence": example.evidence,
                                     }
                                 ),
-                            ),
-                        )
+                            },
+                        }
                     ],
-                )
+                }
             )
 
             # Tool result
@@ -165,7 +164,7 @@ class LeakageJudge:
 
     async def _evaluate_single(
         self,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
     ) -> LeakageJudgment:
         """Run a single evaluation with retry logic.
 
@@ -216,19 +215,19 @@ class LeakageJudge:
             # Retry with error feedback
             if attempt < self._max_retries:
                 messages.append(
-                    SRBenchChatCompletionMessage(
-                        role="assistant",
-                        tool_calls=[
-                            ChatCompletionMessageToolCall(
-                                id=tool_call.id,
-                                type="function",
-                                function=Function(
-                                    name=tool_call.function.name,
-                                    arguments=tool_call.function.arguments,
-                                ),
-                            )
+                    {
+                        "role": "assistant",
+                        "tool_calls": [
+                            {
+                                "id": tool_call.id,
+                                "type": "function",
+                                "function": {
+                                    "name": tool_call.function.name,
+                                    "arguments": tool_call.function.arguments,
+                                },
+                            }
                         ],
-                    )
+                    }
                 )
 
                 error_message = (
@@ -275,7 +274,7 @@ class LeakageJudge:
         user_content = self._build_user_content(input, secret, context)
 
         # Build messages: system prompt, few-shot examples, then actual query
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "system", "content": system_prompt},
         ]
         messages.extend(self._build_example_messages())

--- a/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_artifacts.py
+++ b/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_artifacts.py
@@ -11,7 +11,7 @@ from dotenv import load_dotenv
 from pydantic import BaseModel, Field
 from srbench.benchmarks.calendar_scheduling.loader import load_tasks
 from srbench.benchmarks.calendar_scheduling.types import CalendarTask
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchInputMessage, SRBenchModelClient
 
 # These types were removed from srbench (no longer used at eval time)
 # but are still needed for data-gen artifact generation.
@@ -136,7 +136,7 @@ class ArtifactGenerator:
                 }
             )
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {
                 "role": "user",
                 "content": PROMPT_TEMPLATE.format(

--- a/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_calendars.py
+++ b/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_calendars.py
@@ -5,7 +5,7 @@ from srbench.benchmarks.calendar_scheduling.types import (
     AttendeeStatus,
     LabeledMeeting,
 )
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from .config import PipelineConfig
 from .models import CalendarEvent, Company, Employee, EmployeeCalendar

--- a/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_company.py
+++ b/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_company.py
@@ -1,4 +1,4 @@
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from .config import PipelineConfig
 from .models import Company

--- a/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_employees.py
+++ b/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_employees.py
@@ -1,4 +1,4 @@
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from .config import PipelineConfig
 from .models import Company, Employee, EmployeeRoster

--- a/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_tasks.py
+++ b/packages/srbench-data-gen/srbench_data_gen/calendar_scheduling/generate_tasks.py
@@ -13,7 +13,7 @@ from srbench.benchmarks.calendar_scheduling.types import (
     Meeting,
     TimeSlotPreference,
 )
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from .archetypes import (
     Archetype,

--- a/packages/srbench-data-gen/srbench_data_gen/marketplace/generate_catalog.py
+++ b/packages/srbench-data-gen/srbench_data_gen/marketplace/generate_catalog.py
@@ -3,7 +3,7 @@
 import re
 
 from pydantic import BaseModel, Field
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from .models import CatalogEntry
 

--- a/packages/srbench-llm/src/srbench_llm/__init__.py
+++ b/packages/srbench-llm/src/srbench_llm/__init__.py
@@ -13,12 +13,18 @@ from .concurrency import (
 )
 from .providers.base import SRBenchModelProvider
 from .tracing import LLMTrace, LLMTracer, SRBenchRequest, tracer
-from .types import SRBenchChatCompletionInfo, SRBenchChatCompletionMessage, SRBenchMessage
+from .types import (
+    SRBenchAssistantMessageParam,
+    SRBenchChatCompletionInfo,
+    SRBenchChatCompletionMessage,
+    SRBenchInputMessage,
+)
 
 __all__ = [
     "SRBenchModelClient",
     "SRBenchModelProvider",
-    "SRBenchMessage",
+    "SRBenchInputMessage",
+    "SRBenchAssistantMessageParam",
     "SRBenchChatCompletionMessage",
     "SRBenchChatCompletionInfo",
     "LLMTrace",

--- a/packages/srbench-llm/src/srbench_llm/client.py
+++ b/packages/srbench-llm/src/srbench_llm/client.py
@@ -10,7 +10,7 @@ from pydantic import BaseModel
 
 from .providers import resolve_provider
 from .tracing import LLMTrace, SRBenchRequest, tracer
-from .types import SRBenchChatCompletionMessage, SRBenchMessage
+from .types import SRBenchChatCompletionMessage, SRBenchInputMessage
 
 logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=BaseModel)
@@ -29,7 +29,7 @@ class SRBenchModelClient:
         async def main():
             msg = await client.acomplete(
                 model="anthropic/claude-sonnet-4-5",
-                messages=[SRBenchMessage(role="user", content="Hello")],
+                messages=[{"role": "user", "content": "Hello"}],
             )
             print(msg.content)
 
@@ -51,7 +51,7 @@ class SRBenchModelClient:
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         temperature: float | None = None,
         max_tokens: int | None = None,
@@ -115,7 +115,7 @@ class SRBenchModelClient:
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,

--- a/packages/srbench-llm/src/srbench_llm/providers/anthropic.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/anthropic.py
@@ -195,16 +195,16 @@ def _translate_messages(
     out: list[dict[str, Any]] = []
 
     for msg in messages:
-        role = msg.get("role")
-        content = msg.get("content", "")
-        if role == "system":
-            system = _extract_text(content)
-        elif role == "assistant":
-            out.append(_translate_assistant(cast(SRBenchAssistantMessageParam, msg)))
-        elif role == "tool":
-            out.append(_translate_tool(cast(ChatCompletionToolMessageParam, msg)))
+        # Type checkers only narrow TypedDict unions when the discriminator
+        # is accessed directly in the condition (not stored in a local).
+        if msg["role"] == "system":
+            system = _extract_text(msg.get("content", ""))
+        elif msg["role"] == "assistant":
+            out.append(_translate_assistant(msg))
+        elif msg["role"] == "tool":
+            out.append(_translate_tool(msg))
         else:
-            out.append({"role": "user", "content": _extract_text(content)})
+            out.append({"role": "user", "content": _extract_text(msg.get("content", ""))})
 
     return system, cast(list[MessageParam], out)
 
@@ -261,7 +261,7 @@ def _translate_assistant(msg: SRBenchAssistantMessageParam) -> dict[str, Any]:
 
     for tc in msg.get("tool_calls") or []:
         if tc.get("type") != "function":
-            continue
+            raise ValueError(f"Unsupported tool_call type for Anthropic: {tc.get('type')!r}")
         fn = tc["function"]  # ty: ignore[invalid-key]
         tc_args = fn.get("arguments", "{}")
         blocks.append(

--- a/packages/srbench-llm/src/srbench_llm/providers/anthropic.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/anthropic.py
@@ -18,7 +18,12 @@ from pydantic import BaseModel
 
 from ..concurrency import record_usage, with_llm_retry
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionInfo, SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import (
+    SRBenchAssistantMessageParam,
+    SRBenchChatCompletionInfo,
+    SRBenchChatCompletionMessage,
+    SRBenchInputMessage,
+)
 from .base import SRBenchModelProvider
 
 logger = logging.getLogger(__name__)
@@ -53,7 +58,8 @@ class AnthropicMessage(SRBenchChatCompletionMessage):
     """Anthropic message with native thinking block support.
 
     thinking_blocks carries the raw blocks (including cryptographic signatures)
-    needed for multi-turn thinking preservation.
+    needed for multi-turn thinking preservation. The field is included
+    automatically by ``model_dump`` so no custom serializer is needed.
     """
 
     thinking_blocks: list[dict[str, Any]] | None = None
@@ -75,7 +81,7 @@ class AnthropicProvider(SRBenchModelProvider):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -118,7 +124,7 @@ class AnthropicProvider(SRBenchModelProvider):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,
@@ -163,20 +169,22 @@ class AnthropicProvider(SRBenchModelProvider):
 
 
 # ---------------------------------------------------------------------------
-# Message translation (SRBenchMessage → Anthropic format)
+# Message translation (SRBenchInputMessage → Anthropic format)
 # ---------------------------------------------------------------------------
 
 
 def _translate_messages(
-    messages: list[SRBenchMessage],
+    messages: list[SRBenchInputMessage],
 ) -> tuple[str | anthropic.NotGiven, list[MessageParam]]:
-    """Convert SRBenchMessages to Anthropic format.
+    """Convert SRBench input messages to Anthropic format.
 
-    Returns (system, messages). Thinking blocks from previous AnthropicMessage
-    turns are injected into the assistant message content.
+    Returns (system, messages). For assistant messages, ``thinking_blocks``
+    extension keys (left behind by :meth:`AnthropicMessage.to_input_dict`)
+    are injected into the assistant content so extended-thinking signatures
+    survive across turns.
 
     Args:
-        messages: List of SRBench-typed messages to translate.
+        messages: List of SRBench input messages to translate.
 
     Returns:
         Tuple of ``(system, anthropic_messages)`` where *system* is the
@@ -187,23 +195,16 @@ def _translate_messages(
     out: list[dict[str, Any]] = []
 
     for msg in messages:
-        if isinstance(msg, SRBenchChatCompletionMessage):
-            out.append(_translate_assistant(msg))
-        elif isinstance(msg, dict):
-            content = msg.get("content", "")
-            if msg.get("role") == "system":
-                system = _extract_text(content)
-            elif msg.get("role") == "assistant":
-                out.append(
-                    {
-                        "role": "assistant",
-                        "content": [{"type": "text", "text": _extract_text(content)}],
-                    }
-                )
-            elif msg["role"] == "tool":
-                out.append(_translate_tool(msg))
-            else:
-                out.append({"role": "user", "content": _extract_text(content)})
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "system":
+            system = _extract_text(content)
+        elif role == "assistant":
+            out.append(_translate_assistant(cast(SRBenchAssistantMessageParam, msg)))
+        elif role == "tool":
+            out.append(_translate_tool(cast(ChatCompletionToolMessageParam, msg)))
+        else:
+            out.append({"role": "user", "content": _extract_text(content)})
 
     return system, cast(list[MessageParam], out)
 
@@ -233,36 +234,44 @@ def _extract_text(content: Any) -> str:
     return ""
 
 
-def _translate_assistant(msg: SRBenchChatCompletionMessage) -> dict[str, Any]:
-    """Translate an assistant message, injecting thinking blocks and tool_use.
+def _translate_assistant(msg: SRBenchAssistantMessageParam) -> dict[str, Any]:
+    """Translate an assistant input dict, injecting thinking blocks and tool_use.
+
+    Reads ``thinking_blocks`` from the extension key (set by
+    :meth:`AnthropicMessage.to_input_dict`) so extended-thinking signatures
+    survive across turns.
 
     Args:
-        msg: An assistant-role :class:`SRBenchChatCompletionMessage` (possibly
-            an :class:`AnthropicMessage` with thinking blocks).
+        msg: Assistant-role TypedDict, possibly carrying SRBench extension
+            keys (``thinking_blocks``, ``completion_info``, …).
 
     Returns:
         Anthropic-format message dict with role ``"assistant"``.
     """
     blocks: list[dict[str, Any]] = []
 
-    # Inject thinking blocks if this is an AnthropicMessage with them
-    if isinstance(msg, AnthropicMessage) and msg.thinking_blocks:
-        blocks.extend(msg.thinking_blocks)
+    thinking_blocks = msg.get("thinking_blocks")
+    if thinking_blocks:
+        blocks.extend(thinking_blocks)
 
-    if msg.content:
-        blocks.append({"type": "text", "text": msg.content})
+    content = msg.get("content")
+    text = _extract_text(content) if content is not None else ""
+    if text:
+        blocks.append({"type": "text", "text": text})
 
-    if msg.tool_calls:
-        for tc in msg.tool_calls:
-            if isinstance(tc, ChatCompletionMessageToolCall):
-                blocks.append(
-                    {
-                        "type": "tool_use",
-                        "id": tc.id,
-                        "name": tc.function.name,
-                        "input": json.loads(tc.function.arguments),
-                    }
-                )
+    for tc in msg.get("tool_calls") or []:
+        if tc.get("type") != "function":
+            continue
+        fn = tc["function"]  # ty: ignore[invalid-key]
+        tc_args = fn.get("arguments", "{}")
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": tc["id"],
+                "name": fn["name"],
+                "input": json.loads(tc_args) if tc_args else {},
+            }
+        )
 
     return {"role": "assistant", "content": blocks}
 

--- a/packages/srbench-llm/src/srbench_llm/providers/azure_openai.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/azure_openai.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 
 from ..concurrency import record_usage, with_llm_retry
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import SRBenchChatCompletionMessage, SRBenchInputMessage
 from .base import SRBenchModelProvider
 from .openai import (
     OpenAIMessage,
@@ -87,7 +87,7 @@ class AzureProvider(SRBenchModelProvider):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -131,7 +131,7 @@ class AzureProvider(SRBenchModelProvider):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,

--- a/packages/srbench-llm/src/srbench_llm/providers/azure_pool.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/azure_pool.py
@@ -44,7 +44,7 @@ from ..concurrency import (
     with_llm_retry,
 )
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import SRBenchChatCompletionMessage, SRBenchInputMessage
 from .base import SRBenchModelProvider
 from .openai import (
     _extract_token_details,
@@ -294,7 +294,7 @@ class PooledAzureProvider(SRBenchModelProvider):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -340,7 +340,7 @@ class PooledAzureProvider(SRBenchModelProvider):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,

--- a/packages/srbench-llm/src/srbench_llm/providers/base.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/base.py
@@ -1,13 +1,13 @@
 """Provider ABC."""
 
 from abc import ABC, abstractmethod
-from typing import Any, TypeVar
+from typing import TypeVar
 
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, ChatCompletionToolParam
 from pydantic import BaseModel
 
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import SRBenchChatCompletionMessage, SRBenchInputMessage
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -29,7 +29,7 @@ class SRBenchModelProvider(ABC):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -45,7 +45,7 @@ class SRBenchModelProvider(ABC):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,

--- a/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
@@ -24,7 +24,6 @@ from ..types import (
     SRBenchChatCompletionInfo,
     SRBenchChatCompletionMessage,
     SRBenchInputMessage,
-    decode_signature,
 )
 from .base import SRBenchModelProvider
 
@@ -62,10 +61,6 @@ class GoogleMessage(SRBenchChatCompletionMessage):
     SRBenchChatCompletionMessage so they survive serialization round-trips
     even when the caller stores the message as the base type.
     """
-
-    # No fields beyond the base — relies on inherited thought_parts /
-    # tool_call_signatures and the base ``to_input_dict`` which already
-    # preserves them via SRBENCH_ASSISTANT_EXTENSION_KEYS.
 
 
 class GoogleProvider(SRBenchModelProvider):
@@ -221,10 +216,10 @@ def _translate_request(
     for msg in messages:
         if msg.get("role") != "assistant":
             continue
-        tcs = _iter_tool_calls(msg.get("tool_calls"))
         sigs = msg.get("tool_call_signatures")
-        for i, (tc_id, tc_name, _tc_args) in enumerate(tcs):
-            tc_id_to_name[tc_id] = tc_name
+        for i, tc in enumerate(msg.get("tool_calls") or []):
+            tc_id = tc["id"]
+            tc_id_to_name[tc_id] = tc["function"]["name"]  # ty: ignore[invalid-key]
             has_sig = sigs is not None and i < len(sigs) and sigs[i] is not None
             if not has_sig:
                 unsigned_tc_ids.add(tc_id)
@@ -235,20 +230,21 @@ def _translate_request(
     pending_unsigned: dict[str, str] = {}  # tc_id -> "name(args)"
 
     for msg in messages:
-        role = msg.get("role")
-        content = msg.get("content", "")
-        if role == "system":
-            system_instruction = _extract_text(content)
-        elif role == "assistant":
-            assistant = cast(SRBenchAssistantMessageParam, msg)
-            parts, _text_fallback = _translate_assistant_parts(assistant, unsigned_tc_ids)
+        # Type checkers only narrow TypedDict unions when the discriminator
+        # is accessed directly in the condition (not stored in a local).
+        if msg["role"] == "system":
+            system_instruction = _extract_text(msg.get("content", ""))
+        elif msg["role"] == "assistant":
+            parts, _text_fallback = _translate_assistant_parts(msg, unsigned_tc_ids)
             if parts:
                 contents.append(types.Content(role="model", parts=parts))
             # Buffer unsigned call descriptions — don't emit as model text.
-            for tc_id, tc_name, tc_args in _iter_tool_calls(msg.get("tool_calls")):
+            for tc in msg.get("tool_calls") or []:
+                tc_id = tc["id"]
                 if tc_id in unsigned_tc_ids:
-                    pending_unsigned[tc_id] = f"{tc_name}({tc_args})"
-        elif role == "tool":
+                    fn = tc["function"]  # ty: ignore[invalid-key]
+                    pending_unsigned[tc_id] = f"{fn['name']}({fn.get('arguments', '{}')})"
+        elif msg["role"] == "tool":
             tc_id = str(msg.get("tool_call_id", ""))
             if tc_id in unsigned_tc_ids:
                 # Merge call description + result into a single user message
@@ -259,11 +255,9 @@ def _translate_request(
                     _translate_user(f"Action taken: {call_desc}\nResult: {result_text}")
                 )
             else:
-                contents.append(
-                    _translate_tool_result(cast(ChatCompletionToolMessageParam, msg), tc_id_to_name)
-                )
+                contents.append(_translate_tool_result(msg, tc_id_to_name))
         else:
-            contents.append(_translate_user(_extract_text(content)))
+            contents.append(_translate_user(_extract_text(msg.get("content", ""))))
 
     config = _build_config(
         system_instruction=system_instruction,
@@ -308,19 +302,6 @@ def _extract_text(content: Any) -> str:
     return ""
 
 
-def _iter_tool_calls(tool_calls: Any) -> list[tuple[str, str, str]]:
-    """Normalize a ``tool_calls`` field into ``(id, name, arguments_json)`` tuples.
-
-    Tool calls in input message dicts follow the OpenAI shape
-    ``{"id", "function": {"name", "arguments"}, "type"}``.
-    """
-    out: list[tuple[str, str, str]] = []
-    for tc in tool_calls or []:
-        fn = tc["function"]
-        out.append((tc["id"], fn["name"], fn.get("arguments", "{}")))
-    return out
-
-
 def _translate_assistant_parts(
     msg: SRBenchAssistantMessageParam,
     unsigned_tc_ids: set[str] | None = None,
@@ -347,8 +328,13 @@ def _translate_assistant_parts(
     thought_parts = msg.get("thought_parts")
     if thought_parts:
         for tp in thought_parts:
-            sig = decode_signature(tp.get("thought_signature"))
-            parts.append(types.Part(text=tp.get("text", ""), thought=True, thought_signature=sig))
+            parts.append(
+                types.Part(
+                    text=tp.get("text", ""),
+                    thought=True,
+                    thought_signature=tp.get("thought_signature"),
+                )
+            )
 
     content = msg.get("content")
     text = _extract_text(content) if content is not None else ""
@@ -358,10 +344,13 @@ def _translate_assistant_parts(
     text_fallback_lines: list[str] = []
     signatures = msg.get("tool_call_signatures")
 
-    for i, (tc_id, name, args_json) in enumerate(_iter_tool_calls(msg.get("tool_calls"))):
+    for i, tc in enumerate(msg.get("tool_calls") or []):
+        fn = tc["function"]  # ty: ignore[invalid-key]
+        tc_id = tc["id"]
+        name = fn["name"]
+        args_json = fn.get("arguments", "{}")
         args = json.loads(args_json) if args_json else {}
-        raw_sig = signatures[i] if signatures and i < len(signatures) else None
-        sig = decode_signature(raw_sig)
+        sig = signatures[i] if signatures and i < len(signatures) else None
 
         if tc_id in unsigned_tc_ids:
             # No thought_signature — emit as text instead.

--- a/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
@@ -19,7 +19,13 @@ from pydantic import BaseModel
 
 from ..concurrency import record_usage, with_llm_retry
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionInfo, SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import (
+    SRBenchAssistantMessageParam,
+    SRBenchChatCompletionInfo,
+    SRBenchChatCompletionMessage,
+    SRBenchInputMessage,
+    decode_signature,
+)
 from .base import SRBenchModelProvider
 
 logger = logging.getLogger(__name__)
@@ -57,6 +63,10 @@ class GoogleMessage(SRBenchChatCompletionMessage):
     even when the caller stores the message as the base type.
     """
 
+    # No fields beyond the base — relies on inherited thought_parts /
+    # tool_call_signatures and the base ``to_input_dict`` which already
+    # preserves them via SRBENCH_ASSISTANT_EXTENSION_KEYS.
+
 
 class GoogleProvider(SRBenchModelProvider):
     """Provider for Google Gemini models."""
@@ -69,7 +79,7 @@ class GoogleProvider(SRBenchModelProvider):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -134,7 +144,7 @@ class GoogleProvider(SRBenchModelProvider):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,
@@ -181,12 +191,12 @@ class GoogleProvider(SRBenchModelProvider):
 
 
 # ---------------------------------------------------------------------------
-# Request translation (SRBenchMessage → Google format)
+# Request translation (SRBenchInputMessage → Google format)
 # ---------------------------------------------------------------------------
 
 
 def _translate_request(
-    messages: list[SRBenchMessage],
+    messages: list[SRBenchInputMessage],
     *,
     temperature: float | None = None,
     max_tokens: int | None = None,
@@ -209,14 +219,15 @@ def _translate_request(
     unsigned_tc_ids: set[str] = set()
 
     for msg in messages:
-        if isinstance(msg, SRBenchChatCompletionMessage) and msg.tool_calls:
-            sigs = msg.tool_call_signatures
-            for i, tc in enumerate(msg.tool_calls):
-                if isinstance(tc, ChatCompletionMessageToolCall):
-                    tc_id_to_name[tc.id] = tc.function.name
-                    has_sig = sigs is not None and i < len(sigs) and sigs[i] is not None
-                    if not has_sig:
-                        unsigned_tc_ids.add(tc.id)
+        if msg.get("role") != "assistant":
+            continue
+        tcs = _iter_tool_calls(msg.get("tool_calls"))
+        sigs = msg.get("tool_call_signatures")
+        for i, (tc_id, tc_name, _tc_args) in enumerate(tcs):
+            tc_id_to_name[tc_id] = tc_name
+            has_sig = sigs is not None and i < len(sigs) and sigs[i] is not None
+            if not has_sig:
+                unsigned_tc_ids.add(tc_id)
 
     # Buffer unsigned tool call descriptions so we can merge them with
     # their results into user-role messages (instead of model-role text
@@ -224,40 +235,35 @@ def _translate_request(
     pending_unsigned: dict[str, str] = {}  # tc_id -> "name(args)"
 
     for msg in messages:
-        if isinstance(msg, SRBenchChatCompletionMessage):
-            parts, _text_fallback = _translate_assistant_parts(msg, unsigned_tc_ids)
+        role = msg.get("role")
+        content = msg.get("content", "")
+        if role == "system":
+            system_instruction = _extract_text(content)
+        elif role == "assistant":
+            assistant = cast(SRBenchAssistantMessageParam, msg)
+            parts, _text_fallback = _translate_assistant_parts(assistant, unsigned_tc_ids)
             if parts:
                 contents.append(types.Content(role="model", parts=parts))
             # Buffer unsigned call descriptions — don't emit as model text.
-            if msg.tool_calls:
-                for tc in msg.tool_calls:
-                    if isinstance(tc, ChatCompletionMessageToolCall) and tc.id in unsigned_tc_ids:
-                        pending_unsigned[tc.id] = f"{tc.function.name}({tc.function.arguments})"
-        elif isinstance(msg, dict):
-            content = msg.get("content", "")
-            if msg.get("role") == "system":
-                system_instruction = _extract_text(content)
-            elif msg.get("role") == "assistant":
-                contents.append(
-                    types.Content(
-                        role="model",
-                        parts=[types.Part(text=_extract_text(content))],
-                    )
-                )
-            elif msg["role"] == "tool":
-                tc_id = str(msg.get("tool_call_id", ""))
+            for tc_id, tc_name, tc_args in _iter_tool_calls(msg.get("tool_calls")):
                 if tc_id in unsigned_tc_ids:
-                    # Merge call description + result into a single user message
-                    # so the model never sees model-role text resembling tool calls.
-                    call_desc = pending_unsigned.pop(tc_id, "unknown action")
-                    result_text = msg.get("content", "")
-                    contents.append(
-                        _translate_user(f"Action taken: {call_desc}\nResult: {result_text}")
-                    )
-                else:
-                    contents.append(_translate_tool_result(msg, tc_id_to_name))
+                    pending_unsigned[tc_id] = f"{tc_name}({tc_args})"
+        elif role == "tool":
+            tc_id = str(msg.get("tool_call_id", ""))
+            if tc_id in unsigned_tc_ids:
+                # Merge call description + result into a single user message
+                # so the model never sees model-role text resembling tool calls.
+                call_desc = pending_unsigned.pop(tc_id, "unknown action")
+                result_text = msg.get("content", "")
+                contents.append(
+                    _translate_user(f"Action taken: {call_desc}\nResult: {result_text}")
+                )
             else:
-                contents.append(_translate_user(_extract_text(content)))
+                contents.append(
+                    _translate_tool_result(cast(ChatCompletionToolMessageParam, msg), tc_id_to_name)
+                )
+        else:
+            contents.append(_translate_user(_extract_text(content)))
 
     config = _build_config(
         system_instruction=system_instruction,
@@ -302,15 +308,31 @@ def _extract_text(content: Any) -> str:
     return ""
 
 
+def _iter_tool_calls(tool_calls: Any) -> list[tuple[str, str, str]]:
+    """Normalize a ``tool_calls`` field into ``(id, name, arguments_json)`` tuples.
+
+    Tool calls in input message dicts follow the OpenAI shape
+    ``{"id", "function": {"name", "arguments"}, "type"}``.
+    """
+    out: list[tuple[str, str, str]] = []
+    for tc in tool_calls or []:
+        fn = tc["function"]
+        out.append((tc["id"], fn["name"], fn.get("arguments", "{}")))
+    return out
+
+
 def _translate_assistant_parts(
-    msg: SRBenchChatCompletionMessage,
+    msg: SRBenchAssistantMessageParam,
     unsigned_tc_ids: set[str] | None = None,
 ) -> tuple[list[types.Part], str | None]:
-    """Translate an assistant SRBenchChatCompletionMessage to Google Part list.
+    """Translate an assistant input dict to a Google Part list.
+
+    Reads ``thought_parts`` and ``tool_call_signatures`` from extension keys
+    (set by :meth:`GoogleMessage.to_input_dict`) so Gemini 3+ signatures
+    survive across turns.
 
     Args:
-        msg: An assistant-role message (possibly a :class:`GoogleMessage`
-            with thought parts).
+        msg: Assistant-role TypedDict, possibly with SRBench extension keys.
         unsigned_tc_ids: Tool call IDs that lack a thought_signature.  These
             are collapsed to a text description instead of a ``function_call``
             Part so Gemini 3+ models don't reject the request.
@@ -322,36 +344,35 @@ def _translate_assistant_parts(
     parts: list[types.Part] = []
     unsigned_tc_ids = unsigned_tc_ids or set()
 
-    # Inject thought parts from previous turns
-    if msg.thought_parts:
-        for tp in msg.thought_parts:
-            sig = tp.get("thought_signature")
+    thought_parts = msg.get("thought_parts")
+    if thought_parts:
+        for tp in thought_parts:
+            sig = decode_signature(tp.get("thought_signature"))
             parts.append(types.Part(text=tp.get("text", ""), thought=True, thought_signature=sig))
 
-    if msg.content:
-        parts.append(types.Part(text=msg.content))
+    content = msg.get("content")
+    text = _extract_text(content) if content is not None else ""
+    if text:
+        parts.append(types.Part(text=text))
 
     text_fallback_lines: list[str] = []
+    signatures = msg.get("tool_call_signatures")
 
-    if msg.tool_calls:
-        signatures = msg.tool_call_signatures
+    for i, (tc_id, name, args_json) in enumerate(_iter_tool_calls(msg.get("tool_calls"))):
+        args = json.loads(args_json) if args_json else {}
+        raw_sig = signatures[i] if signatures and i < len(signatures) else None
+        sig = decode_signature(raw_sig)
 
-        for i, tc in enumerate(msg.tool_calls):
-            if isinstance(tc, ChatCompletionMessageToolCall):
-                name = tc.function.name
-                args = json.loads(tc.function.arguments)
-                sig = signatures[i] if signatures and i < len(signatures) else None
-
-                if tc.id in unsigned_tc_ids:
-                    # No thought_signature — emit as text instead.
-                    text_fallback_lines.append(f"[Called {name}({json.dumps(args)})]")
-                else:
-                    parts.append(
-                        types.Part(
-                            function_call=types.FunctionCall(name=name, args=args),
-                            thought_signature=sig,
-                        )
-                    )
+        if tc_id in unsigned_tc_ids:
+            # No thought_signature — emit as text instead.
+            text_fallback_lines.append(f"[Called {name}({json.dumps(args)})]")
+        else:
+            parts.append(
+                types.Part(
+                    function_call=types.FunctionCall(name=name, args=args),
+                    thought_signature=sig,
+                )
+            )
 
     text_fallback = "\n".join(text_fallback_lines) if text_fallback_lines else None
     return parts, text_fallback

--- a/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/google_genai.py
@@ -349,6 +349,7 @@ def _translate_assistant_parts(
         tc_id = tc["id"]
         name = fn["name"]
         args_json = fn.get("arguments", "{}")
+        # Empty/missing arguments are deliberately treated as no arguments.
         args = json.loads(args_json) if args_json else {}
         sig = signatures[i] if signatures and i < len(signatures) else None
 

--- a/packages/srbench-llm/src/srbench_llm/providers/openai.py
+++ b/packages/srbench-llm/src/srbench_llm/providers/openai.py
@@ -14,7 +14,12 @@ from pydantic import BaseModel
 
 from ..concurrency import record_usage, with_llm_retry
 from ..tracing import LLMTrace
-from ..types import SRBenchChatCompletionInfo, SRBenchChatCompletionMessage, SRBenchMessage
+from ..types import (
+    SRBENCH_ASSISTANT_EXTENSION_KEYS,
+    SRBenchChatCompletionInfo,
+    SRBenchChatCompletionMessage,
+    SRBenchInputMessage,
+)
 from .base import SRBenchModelProvider
 
 logger = logging.getLogger(__name__)
@@ -66,7 +71,7 @@ class OpenAIProvider(SRBenchModelProvider):
     async def acomplete(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         *,
         trace: LLMTrace,
         temperature: float | None = None,
@@ -110,7 +115,7 @@ class OpenAIProvider(SRBenchModelProvider):
     async def aparse(
         self,
         model: str,
-        messages: list[SRBenchMessage],
+        messages: list[SRBenchInputMessage],
         response_format: type[T],
         *,
         temperature: float | None = None,
@@ -172,19 +177,24 @@ class OpenAIProvider(SRBenchModelProvider):
 # ---------------------------------------------------------------------------
 
 
-def _to_openai_messages(messages: list[SRBenchMessage]) -> list[ChatCompletionMessageParam]:
-    """Convert SRBenchMessages to OpenAI-format message params.
+def _to_openai_messages(messages: list[SRBenchInputMessage]) -> list[ChatCompletionMessageParam]:
+    """Convert SRBench input messages to OpenAI-format message params.
+
+    Assistant dicts may carry SRBench extension keys (see
+    :data:`SRBENCH_ASSISTANT_EXTENSION_KEYS`); these are stripped because the
+    OpenAI SDK rejects unknown keys.
 
     Args:
-        messages: List of SRBench-typed messages to translate.
+        messages: List of SRBench input messages to translate.
 
     Returns:
         List of OpenAI :class:`ChatCompletionMessageParam` dicts.
     """
     out: list[ChatCompletionMessageParam] = []
     for msg in messages:
-        if isinstance(msg, SRBenchChatCompletionMessage):
-            out.append(msg.model_dump(exclude_none=True, exclude={"completion_info"}))
+        if msg.get("role") == "assistant":
+            cleaned = {k: v for k, v in msg.items() if k not in SRBENCH_ASSISTANT_EXTENSION_KEYS}
+            out.append(cast(ChatCompletionMessageParam, cleaned))
         else:
             out.append(msg)
     return out

--- a/packages/srbench-llm/src/srbench_llm/tracing.py
+++ b/packages/srbench-llm/src/srbench_llm/tracing.py
@@ -4,7 +4,7 @@ Every trace captures four layers of the request/response lifecycle:
 1. srbench_request    — the SRBench-typed request (model, SRBenchMessages, kwargs)
 2. provider_request   — the translated provider-specific request (SDK kwargs)
 3. provider_response  — the raw provider-specific response (SDK object, serialized)
-4. srbench_response   — the transformed SRBench-typed response (SRBenchMessage)
+4. srbench_response   — the transformed SRBench-typed response (SRBenchChatCompletionMessage)
 
 A single ``LLMTrace`` object is created by the client, passed to the
 provider (which fills layers 2/3 and usage), then finalized by the
@@ -28,7 +28,7 @@ from typing import Any
 from openai.types.chat import ChatCompletionToolChoiceOptionParam, ChatCompletionToolParam
 from pydantic import BaseModel, Field
 
-from .types import SRBenchChatCompletionMessage, SRBenchMessage
+from .types import SRBenchChatCompletionMessage, SRBenchInputMessage
 
 # ---------------------------------------------------------------------------
 # Trace
@@ -39,7 +39,7 @@ class SRBenchRequest(BaseModel):
     """Layer 1: SRBench-typed request."""
 
     model: str
-    messages: list[SRBenchMessage] = Field(default_factory=list)
+    messages: list[SRBenchInputMessage] = Field(default_factory=list)
     temperature: float | None = None
     max_tokens: int | None = None
     top_p: float | None = None

--- a/packages/srbench-llm/src/srbench_llm/types.py
+++ b/packages/srbench-llm/src/srbench_llm/types.py
@@ -1,11 +1,37 @@
-"""Core types for srbench-llm."""
+"""Core types for srbench-llm.
 
-from typing import Annotated, Any, Union, cast
+The message type system has two strictly separated halves:
 
-from openai.types.chat import ChatCompletionMessage, ChatCompletionMessageParam
+* **Input messages** (TypedDicts): what callers pass to
+  :meth:`SRBenchModelClient.acomplete`. The :data:`SRBenchInputMessage` union
+  covers system / user / assistant / tool messages, plus an extended
+  :class:`SRBenchAssistantMessageParam` variant that carries provider-specific
+  metadata (Anthropic ``thinking_blocks``, Gemini ``thought_parts`` /
+  ``tool_call_signatures``) across turns.
+
+* **Output messages** (Pydantic BaseModel): what providers return from
+  :meth:`SRBenchModelClient.acomplete`. :class:`SRBenchChatCompletionMessage`
+  is the base; providers subclass it (e.g. ``AnthropicMessage``,
+  ``GoogleMessage``) to attach native fields. Calling ``model_dump(mode="json",
+  exclude_none=True)`` on the BaseModel produces a
+  :class:`SRBenchAssistantMessageParam`-shaped dict ready to be appended into
+  the next turn's input list — field serializers handle the bytes-encoding and
+  ``completion_info`` exclusion automatically.
+"""
+
+import base64
+from typing import Any, TypeAlias, Union, cast
+
+from openai.types.chat import (
+    ChatCompletionAssistantMessageParam,
+    ChatCompletionMessage,
+    ChatCompletionSystemMessageParam,
+    ChatCompletionToolMessageParam,
+    ChatCompletionUserMessageParam,
+)
 from openai.types.completion_usage import CompletionUsage
-from pydantic import BaseModel, PlainSerializer, PlainValidator
-from pydantic_core import from_json, to_json
+from pydantic import BaseModel, Field, SkipValidation, field_serializer
+from typing_extensions import NotRequired
 
 
 class SRBenchChatCompletionInfo(BaseModel):
@@ -18,15 +44,121 @@ class SRBenchChatCompletionInfo(BaseModel):
     usage: CompletionUsage | None = None
 
 
-class SRBenchChatCompletionMessage(ChatCompletionMessage):
-    """Assistant message with response metadata.
+class SRBenchAssistantMessageParam(ChatCompletionAssistantMessageParam, total=False):
+    """Extended OpenAI assistant TypedDict carrying SRBench/provider metadata.
 
-    Role is always ``"assistant"`` (inherited from ChatCompletionMessage).
-    Provider subclasses (AnthropicMessage, GoogleMessage, etc.) extend this
-    with provider-specific fields like thinking_blocks.
+    Inherits every field of :class:`ChatCompletionAssistantMessageParam`
+    (``role``, ``content``, ``tool_calls``, ``refusal``, …) and adds four
+    optional extension keys used to round-trip provider-specific information
+    across turns:
+
+    * ``completion_info`` — :class:`SRBenchChatCompletionInfo` for this turn.
+    * ``thinking_blocks`` — Anthropic native thinking blocks (signatures
+      included), required to round-trip extended thinking.
+    * ``thought_parts`` — Gemini 3+ thought parts with ``thought_signature``
+      values that must be preserved across multi-turn tool-use conversations.
+    * ``tool_call_signatures`` — per-tool-call signatures from Gemini 3+.
+
+    Providers must strip these extension keys before handing the dict to the
+    underlying SDK.
     """
 
-    completion_info: SRBenchChatCompletionInfo | None = None
+    completion_info: NotRequired[SRBenchChatCompletionInfo | dict[str, Any] | None]
+    thinking_blocks: NotRequired[list[dict[str, Any]] | None]
+    # ``thought_signature`` values inside ``thought_parts`` and entries of
+    # ``tool_call_signatures`` are base64-encoded strings of the raw Gemini
+    # signature bytes. Use :func:`decode_signature` to turn them back into
+    # bytes before passing to the Gemini SDK.
+    thought_parts: NotRequired[list[dict[str, Any]] | None]
+    tool_call_signatures: NotRequired[list[str | None] | None]
+
+
+SRBenchInputMessage: TypeAlias = SkipValidation[
+    Union[
+        ChatCompletionSystemMessageParam,
+        ChatCompletionUserMessageParam,
+        SRBenchAssistantMessageParam,
+        ChatCompletionToolMessageParam,
+    ]
+]
+"""Strict TypedDict union of all messages that flow *into* the LLM stack.
+
+The assistant variant is :class:`SRBenchAssistantMessageParam`, which extends
+:class:`ChatCompletionAssistantMessageParam` with optional extension keys
+(``completion_info``, ``thinking_blocks``, ``thought_parts``,
+``tool_call_signatures``). A plain ``ChatCompletionAssistantMessageParam`` dict
+is structurally compatible — it just omits the extension keys.
+
+The :class:`SkipValidation` wrapper is essential: OpenAI's TypedDicts declare
+``tool_calls`` as ``Iterable[...]``, and pydantic eagerly validates that into a
+single-consume ``ValidatorIterator`` that gets exhausted by the first reader
+(provider translation, retry, eval). Skipping validation stores the dicts
+verbatim. This also avoids the pydantic smart-union serializer footgun where
+having both ``ChatCompletionAssistantMessageParam`` and
+:class:`SRBenchAssistantMessageParam` in a union confuses dispatch and drops
+``tool_calls`` from output.
+"""
+
+
+# Keys produced by :meth:`SRBenchChatCompletionMessage.to_input_dict` that are
+# NOT part of the standard OpenAI assistant message. Providers strip these
+# before handing the dict to the underlying SDK.
+SRBENCH_ASSISTANT_EXTENSION_KEYS: frozenset[str] = frozenset(
+    {"completion_info", "thinking_blocks", "thought_parts", "tool_call_signatures"}
+)
+
+
+def encode_signature(sig: bytes | str | None) -> str | None:
+    """Base64-encode a Gemini signature for storage in a TypedDict.
+
+    The TypedDict shape is JSON-friendly; raw bytes inside ``dict[str, Any]``
+    fields trip pydantic's serializer (UTF-8 decode error on binary). Strings
+    pass through unchanged (they are presumed already-encoded, e.g. when a
+    BaseModel was reconstructed from a JSON dump that stored the field inside
+    a ``dict[str, Any]`` typed parent).
+    """
+    if sig is None:
+        return None
+    if isinstance(sig, str):
+        return sig
+    return base64.b64encode(sig).decode("ascii")
+
+
+def decode_signature(sig: str | bytes | None) -> bytes | None:
+    """Inverse of :func:`encode_signature`. Tolerates raw bytes for back-compat."""
+    if sig is None:
+        return None
+    if isinstance(sig, bytes):
+        return sig
+    return base64.b64decode(sig)
+
+
+class SRBenchChatCompletionMessage(ChatCompletionMessage):
+    """Assistant output message produced by an LLM provider.
+
+    Role is always ``"assistant"`` (inherited from
+    :class:`ChatCompletionMessage`). Provider subclasses
+    (``AnthropicMessage``, ``GoogleMessage``, ``OpenAIMessage``) extend this
+    with native fields like ``thinking_blocks``.
+
+    Field serializers shape ``model_dump`` output into a
+    :class:`SRBenchAssistantMessageParam` dict:
+
+    * ``completion_info`` is excluded (provider response metadata, not part of
+      the input conversation).
+    * ``tool_call_signatures`` is base64-encoded (raw bytes can't survive
+      JSON serialization).
+    * ``thought_parts`` has its inner ``thought_signature`` bytes
+      base64-encoded.
+
+    To feed a response into the next turn, call
+    ``msg.model_dump(mode="json", exclude_none=True)`` — the result is
+    structurally a :class:`SRBenchAssistantMessageParam`. The Gemini provider
+    uses :func:`decode_signature` to recover the raw bytes before handing
+    them to the SDK.
+    """
+
+    completion_info: SRBenchChatCompletionInfo | None = Field(default=None, exclude=True)
 
     # Google-specific fields that must survive serialization round-trips so
     # that thought_signature values are preserved across multi-turn tool-use
@@ -34,83 +166,37 @@ class SRBenchChatCompletionMessage(ChatCompletionMessage):
     thought_parts: list[dict[str, Any]] | None = None
     tool_call_signatures: list[bytes | None] | None = None
 
+    @field_serializer("tool_call_signatures")
+    def _ser_tool_call_signatures(self, v: list[bytes | None] | None) -> list[str | None] | None:
+        if v is None:
+            return None
+        return [encode_signature(s) for s in v]
 
-def _validate_sage_message(msg: Any) -> Any:
-    """Validate and discriminate SRBenchMessage input.
+    @field_serializer("thought_parts")
+    def _ser_thought_parts(self, v: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
+        """Base64-encode the bytes-valued ``thought_signature`` inside each part.
 
-    - SRBenchChatCompletionMessage instances pass through unchanged.
-    - Dicts with ``role: "assistant"`` are promoted to SRBenchChatCompletionMessage
-      so round-tripping through JSON preserves the concrete type.
-    - Other dicts (system/user/tool messages) stay as plain dicts.
+        Pydantic's default serializer doesn't know to encode bytes that sit
+        inside a ``dict[str, Any]`` typed field; we do it explicitly so the
+        resulting dict is JSON-safe.
+        """
+        if v is None:
+            return None
+        out: list[dict[str, Any]] = []
+        for tp in v:
+            encoded: dict[str, Any] = {k: val for k, val in tp.items() if k != "thought_signature"}
+            sig = tp.get("thought_signature")
+            if sig is not None:
+                encoded["thought_signature"] = encode_signature(sig)
+            out.append(encoded)
+        return out
 
-    Args:
-        msg: Raw message value — a :class:`BaseModel`, dict, or other type.
+    def to_input_dict(self) -> SRBenchAssistantMessageParam:
+        """Typed shim over :meth:`model_dump` for next-turn input lists.
 
-    Returns:
-        The validated message, possibly promoted to
-        :class:`SRBenchChatCompletionMessage`.
-
-    Raises:
-        ValueError: If *msg* is not a BaseModel or dict.
-    """
-    if isinstance(msg, SRBenchChatCompletionMessage):
-        return msg
-    if isinstance(msg, BaseModel):
-        # Some other pydantic model (e.g. ChatCompletionMessage from openai) — convert
-        return msg
-    if isinstance(msg, dict):
-        if msg.get("role") == "assistant":
-            return SRBenchChatCompletionMessage.model_validate(msg)
-        return msg
-    raise ValueError(
-        f"SRBenchMessage must be a BaseModel or dict, got {type(msg).__name__}: {msg!r:.200}"
-    )
-
-
-def _serialize_sage_message(
-    msg: SRBenchChatCompletionMessage | ChatCompletionMessageParam,
-) -> dict[str, Any]:
-    """Serialize any SRBenchMessage variant to a JSON-safe dict.
-
-    Handles:
-    - Pydantic models (SRBenchChatCompletionMessage) → model_dump
-    - TypedDicts / plain dicts (ChatCompletionMessageParam) → recursive serialization
-    - Unexpected types → string fallback
-
-    Args:
-        msg: A :class:`SRBenchChatCompletionMessage` or
-            :class:`ChatCompletionMessageParam` dict.
-
-    Returns:
-        JSON-safe dict representation of the message.
-
-    Raises:
-        ValueError: If *msg* is not a supported message type.
-    """
-    if isinstance(msg, SRBenchChatCompletionMessage):
-        data = msg.model_dump(mode="json", exclude={"tool_call_signatures"})
-        # Strip binary thought_signature from thought_parts dicts
-        if data.get("thought_parts"):
-            data["thought_parts"] = [
-                {k: v for k, v in tp.items() if k != "thought_signature"}
-                for tp in data["thought_parts"]
-            ]
-        return data
-    elif isinstance(msg, dict):
-        return cast(dict[str, Any], msg)
-    raise ValueError(f"Cannot serialize SRBenchMessage of type {type(msg).__name__}: {msg!r:.200}")
-
-
-SRBenchMessage = Annotated[
-    Union[SRBenchChatCompletionMessage, ChatCompletionMessageParam],
-    PlainValidator(_validate_sage_message),
-    PlainSerializer(_serialize_sage_message, return_type=dict),
-]
-"""Union of all message types that flow through the srbench-llm stack.
-
-- SRBenchChatCompletionMessage: assistant responses (rich, with completion_info)
-- ChatCompletionMessageParam: input messages (system, user, tool dicts)
-
-Annotated with a PlainSerializer so pydantic can round-trip the union
-through JSON without choking on TypedDict validation.
-"""
+        Field serializers (above) do the actual transformation:
+        ``completion_info`` is excluded, byte-valued signatures are
+        base64-encoded. This helper just narrows the return type from
+        ``dict[str, Any]`` to :class:`SRBenchAssistantMessageParam`.
+        """
+        return cast(SRBenchAssistantMessageParam, self.model_dump(mode="json", exclude_none=True))

--- a/packages/srbench-llm/src/srbench_llm/types.py
+++ b/packages/srbench-llm/src/srbench_llm/types.py
@@ -12,14 +12,12 @@ The message type system has two strictly separated halves:
 * **Output messages** (Pydantic BaseModel): what providers return from
   :meth:`SRBenchModelClient.acomplete`. :class:`SRBenchChatCompletionMessage`
   is the base; providers subclass it (e.g. ``AnthropicMessage``,
-  ``GoogleMessage``) to attach native fields. Calling ``model_dump(mode="json",
-  exclude_none=True)`` on the BaseModel produces a
-  :class:`SRBenchAssistantMessageParam`-shaped dict ready to be appended into
-  the next turn's input list — field serializers handle the bytes-encoding and
-  ``completion_info`` exclusion automatically.
+  ``GoogleMessage``) to attach native fields. Calling ``to_input_dict()``
+  produces a :class:`SRBenchAssistantMessageParam`-shaped dict ready to be
+  appended into the next turn's input list.
 """
 
-import base64
+from collections.abc import Iterable, Mapping
 from typing import Any, TypeAlias, Union, cast
 
 from openai.types.chat import (
@@ -55,9 +53,14 @@ class SRBenchAssistantMessageParam(ChatCompletionAssistantMessageParam, total=Fa
     * ``completion_info`` — :class:`SRBenchChatCompletionInfo` for this turn.
     * ``thinking_blocks`` — Anthropic native thinking blocks (signatures
       included), required to round-trip extended thinking.
-    * ``thought_parts`` — Gemini 3+ thought parts with ``thought_signature``
-      values that must be preserved across multi-turn tool-use conversations.
-    * ``tool_call_signatures`` — per-tool-call signatures from Gemini 3+.
+    * ``thought_parts`` — Gemini 3+ thought parts. Each part's
+      ``thought_signature`` value is raw ``bytes``.
+    * ``tool_call_signatures`` — per-tool-call signatures from Gemini 3+,
+      as raw ``bytes``.
+
+    The signature fields hold raw bytes because they only live in-memory —
+    parent result/checkpoint models strip them before JSON serialization
+    (see ``strip_signatures_from_messages``).
 
     Providers must strip these extension keys before handing the dict to the
     underlying SDK.
@@ -65,12 +68,8 @@ class SRBenchAssistantMessageParam(ChatCompletionAssistantMessageParam, total=Fa
 
     completion_info: NotRequired[SRBenchChatCompletionInfo | dict[str, Any] | None]
     thinking_blocks: NotRequired[list[dict[str, Any]] | None]
-    # ``thought_signature`` values inside ``thought_parts`` and entries of
-    # ``tool_call_signatures`` are base64-encoded strings of the raw Gemini
-    # signature bytes. Use :func:`decode_signature` to turn them back into
-    # bytes before passing to the Gemini SDK.
     thought_parts: NotRequired[list[dict[str, Any]] | None]
-    tool_call_signatures: NotRequired[list[str | None] | None]
+    tool_call_signatures: NotRequired[list[bytes | None] | None]
 
 
 SRBenchInputMessage: TypeAlias = SkipValidation[
@@ -108,29 +107,23 @@ SRBENCH_ASSISTANT_EXTENSION_KEYS: frozenset[str] = frozenset(
 )
 
 
-def encode_signature(sig: bytes | str | None) -> str | None:
-    """Base64-encode a Gemini signature for storage in a TypedDict.
+# Extension keys whose values are raw bytes that can't be JSON-serialized.
+# Parent result/checkpoint models strip these before disk write — the
+# signatures only matter mid-conversation, not across restarts.
+SRBENCH_SIGNATURE_KEYS: frozenset[str] = frozenset({"thought_parts", "tool_call_signatures"})
 
-    The TypedDict shape is JSON-friendly; raw bytes inside ``dict[str, Any]``
-    fields trip pydantic's serializer (UTF-8 decode error on binary). Strings
-    pass through unchanged (they are presumed already-encoded, e.g. when a
-    BaseModel was reconstructed from a JSON dump that stored the field inside
-    a ``dict[str, Any]`` typed parent).
+
+def strip_signatures_from_messages(
+    messages: Iterable[Mapping[str, Any]],
+) -> list[dict[str, Any]]:
+    """Return messages with bytes-bearing signature keys removed.
+
+    Use as a ``field_serializer(..., when_used="json")`` on any pydantic field
+    that holds a ``list[SRBenchInputMessage]`` and gets dumped to JSON
+    (results files, checkpoints, traces). The signatures are only useful
+    inside a single in-memory task lifecycle.
     """
-    if sig is None:
-        return None
-    if isinstance(sig, str):
-        return sig
-    return base64.b64encode(sig).decode("ascii")
-
-
-def decode_signature(sig: str | bytes | None) -> bytes | None:
-    """Inverse of :func:`encode_signature`. Tolerates raw bytes for back-compat."""
-    if sig is None:
-        return None
-    if isinstance(sig, bytes):
-        return sig
-    return base64.b64decode(sig)
+    return [{k: v for k, v in msg.items() if k not in SRBENCH_SIGNATURE_KEYS} for msg in messages]
 
 
 class SRBenchChatCompletionMessage(ChatCompletionMessage):
@@ -141,62 +134,36 @@ class SRBenchChatCompletionMessage(ChatCompletionMessage):
     (``AnthropicMessage``, ``GoogleMessage``, ``OpenAIMessage``) extend this
     with native fields like ``thinking_blocks``.
 
-    Field serializers shape ``model_dump`` output into a
-    :class:`SRBenchAssistantMessageParam` dict:
+    ``completion_info`` is excluded from ``model_dump`` (response metadata,
+    not part of the input conversation). The bytes-valued signature fields
+    (``thought_parts`` and ``tool_call_signatures``) are dropped on JSON
+    serialization — they only matter in-memory for the current task and
+    are not worth round-tripping through disk.
 
-    * ``completion_info`` is excluded (provider response metadata, not part of
-      the input conversation).
-    * ``tool_call_signatures`` is base64-encoded (raw bytes can't survive
-      JSON serialization).
-    * ``thought_parts`` has its inner ``thought_signature`` bytes
-      base64-encoded.
-
-    To feed a response into the next turn, call
-    ``msg.model_dump(mode="json", exclude_none=True)`` — the result is
-    structurally a :class:`SRBenchAssistantMessageParam`. The Gemini provider
-    uses :func:`decode_signature` to recover the raw bytes before handing
-    them to the SDK.
+    To feed a response into the next turn, call :meth:`to_input_dict`.
     """
 
     completion_info: SRBenchChatCompletionInfo | None = Field(default=None, exclude=True)
 
-    # Google-specific fields that must survive serialization round-trips so
-    # that thought_signature values are preserved across multi-turn tool-use
-    # conversations.  Gemini 3+ models reject requests that omit these.
+    # Google-specific fields used in-memory to round-trip thought_signature
+    # values across multi-turn tool-use conversations.  Gemini 3+ models
+    # reject requests that omit these.  Dropped at JSON-serialization time.
     thought_parts: list[dict[str, Any]] | None = None
     tool_call_signatures: list[bytes | None] | None = None
 
-    @field_serializer("tool_call_signatures")
-    def _ser_tool_call_signatures(self, v: list[bytes | None] | None) -> list[str | None] | None:
-        if v is None:
-            return None
-        return [encode_signature(s) for s in v]
+    @field_serializer("tool_call_signatures", when_used="json")
+    def _drop_tool_call_signatures(self, _v: list[bytes | None] | None) -> None:
+        return None
 
-    @field_serializer("thought_parts")
-    def _ser_thought_parts(self, v: list[dict[str, Any]] | None) -> list[dict[str, Any]] | None:
-        """Base64-encode the bytes-valued ``thought_signature`` inside each part.
-
-        Pydantic's default serializer doesn't know to encode bytes that sit
-        inside a ``dict[str, Any]`` typed field; we do it explicitly so the
-        resulting dict is JSON-safe.
-        """
-        if v is None:
-            return None
-        out: list[dict[str, Any]] = []
-        for tp in v:
-            encoded: dict[str, Any] = {k: val for k, val in tp.items() if k != "thought_signature"}
-            sig = tp.get("thought_signature")
-            if sig is not None:
-                encoded["thought_signature"] = encode_signature(sig)
-            out.append(encoded)
-        return out
+    @field_serializer("thought_parts", when_used="json")
+    def _drop_thought_parts(self, _v: list[dict[str, Any]] | None) -> None:
+        return None
 
     def to_input_dict(self) -> SRBenchAssistantMessageParam:
-        """Typed shim over :meth:`model_dump` for next-turn input lists.
+        """Dump this message as a dict ready for the next turn's input list.
 
-        Field serializers (above) do the actual transformation:
-        ``completion_info`` is excluded, byte-valued signatures are
-        base64-encoded. This helper just narrows the return type from
-        ``dict[str, Any]`` to :class:`SRBenchAssistantMessageParam`.
+        Uses ``mode="python"`` so raw bytes survive in ``thought_parts`` and
+        ``tool_call_signatures`` — providers consume them directly.
+        ``completion_info`` is excluded via the Field declaration.
         """
-        return cast(SRBenchAssistantMessageParam, self.model_dump(mode="json", exclude_none=True))
+        return cast(SRBenchAssistantMessageParam, self.model_dump(mode="python", exclude_none=True))

--- a/packages/srbench-llm/tests/providers/test_anthropic.py
+++ b/packages/srbench-llm/tests/providers/test_anthropic.py
@@ -28,7 +28,7 @@ from srbench_llm.providers.anthropic import (
     _translate_tools,
 )
 from srbench_llm.tracing import LLMTrace
-from srbench_llm.types import SRBenchChatCompletionMessage, SRBenchMessage
+from srbench_llm.types import SRBenchChatCompletionMessage, SRBenchInputMessage
 
 
 def _make_anthropic_response(
@@ -53,7 +53,7 @@ def _make_anthropic_response(
 
 class TestTranslateMessages:
     def test_extracts_system(self):
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "system", "content": "be helpful"},
             {"role": "user", "content": "hi"},
         ]
@@ -65,14 +65,14 @@ class TestTranslateMessages:
         assert m["role"] == "user"
 
     def test_user_message(self):
-        msgs: list[SRBenchMessage] = [{"role": "user", "content": "hello"}]
+        msgs: list[SRBenchInputMessage] = [{"role": "user", "content": "hello"}]
         system, out = _translate_messages(msgs)
         assert isinstance(system, anthropic.NotGiven)
         assert out[0] == {"role": "user", "content": "hello"}
 
     def test_assistant_message_with_content(self):
-        msgs: list[SRBenchMessage] = [
-            SRBenchChatCompletionMessage(role="assistant", content="answer")
+        msgs: list[SRBenchInputMessage] = [
+            SRBenchChatCompletionMessage(role="assistant", content="answer").to_input_dict()
         ]
         _, out = _translate_messages(msgs)
         m = out[0]
@@ -87,8 +87,10 @@ class TestTranslateMessages:
 
     def test_assistant_message_injects_thinking_blocks(self):
         thinking = [{"type": "thinking", "thinking": "hmm...", "signature": "sig123"}]
-        msgs: list[SRBenchMessage] = [
-            AnthropicMessage(role="assistant", content="answer", thinking_blocks=thinking)
+        msgs: list[SRBenchInputMessage] = [
+            AnthropicMessage(
+                role="assistant", content="answer", thinking_blocks=thinking
+            ).to_input_dict()
         ]
         _, out = _translate_messages(msgs)
 
@@ -105,8 +107,10 @@ class TestTranslateMessages:
             type="function",
             function=Function(name="search", arguments='{"q": "test"}'),
         )
-        msgs: list[SRBenchMessage] = [
-            SRBenchChatCompletionMessage(role="assistant", content=None, tool_calls=[tc])
+        msgs: list[SRBenchInputMessage] = [
+            SRBenchChatCompletionMessage(
+                role="assistant", content=None, tool_calls=[tc]
+            ).to_input_dict()
         ]
         _, out = _translate_messages(msgs)
 

--- a/packages/srbench-llm/tests/providers/test_azure.py
+++ b/packages/srbench-llm/tests/providers/test_azure.py
@@ -9,7 +9,6 @@ from openai.types.completion_usage import CompletionUsage
 from srbench_llm.providers.azure_openai import AzureProvider
 from srbench_llm.providers.openai import OpenAIMessage
 from srbench_llm.tracing import LLMTrace
-from srbench_llm.types import SRBenchMessage
 
 
 def _make_chat_completion(content="Hello!") -> ChatCompletion:

--- a/packages/srbench-llm/tests/providers/test_google.py
+++ b/packages/srbench-llm/tests/providers/test_google.py
@@ -30,7 +30,7 @@ from srbench_llm.providers.google_genai import (
     _translate_tools,
 )
 from srbench_llm.tracing import LLMTrace
-from srbench_llm.types import SRBenchChatCompletionMessage, SRBenchMessage
+from srbench_llm.types import SRBenchChatCompletionMessage, SRBenchInputMessage
 
 
 def _make_google_response(
@@ -71,7 +71,7 @@ def _make_google_response(
 
 class TestTranslateRequest:
     def test_system_extracted(self):
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "system", "content": "be helpful"},
             {"role": "user", "content": "hi"},
         ]
@@ -81,7 +81,7 @@ class TestTranslateRequest:
         assert config.system_instruction == "be helpful"
 
     def test_user_message(self):
-        msgs: list[SRBenchMessage] = [{"role": "user", "content": "hello"}]
+        msgs: list[SRBenchInputMessage] = [{"role": "user", "content": "hello"}]
         raw_contents, _ = _translate_request(msgs)
         assert isinstance(raw_contents, list)
         contents = cast(list[types.Content], raw_contents)
@@ -91,8 +91,8 @@ class TestTranslateRequest:
         assert contents[0].parts[0].text == "hello"
 
     def test_assistant_message(self):
-        msgs: list[SRBenchMessage] = [
-            SRBenchChatCompletionMessage(role="assistant", content="reply")
+        msgs: list[SRBenchInputMessage] = [
+            SRBenchChatCompletionMessage(role="assistant", content="reply").to_input_dict()
         ]
         raw_contents, _ = _translate_request(msgs)
         assert isinstance(raw_contents, list)
@@ -100,12 +100,12 @@ class TestTranslateRequest:
         assert contents[0].role == "model"
 
     def test_thought_parts_injected(self):
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             GoogleMessage(
                 role="assistant",
                 content="answer",
                 thought_parts=[{"text": "thinking...", "thought": True}],
-            )
+            ).to_input_dict()
         ]
         raw_contents, _ = _translate_request(msgs)
         assert isinstance(raw_contents, list)
@@ -224,9 +224,9 @@ class TestTranslateRequestToolNameResolution:
             tool_call_signatures=[b"sig"],
         )
         tool_msg = _tool_msg('{"temp": 55}', "call_abc")
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather?"},
-            assistant_msg,
+            assistant_msg.to_input_dict(),
             tool_msg,
         ]
         raw_contents, _ = _translate_request(msgs)
@@ -254,9 +254,9 @@ class TestTranslateRequestToolNameResolution:
             ],
             tool_call_signatures=[b"sig1", b"sig2"],
         )
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "user", "content": "hi"},
-            assistant_msg,
+            assistant_msg.to_input_dict(),
             _tool_msg("sunny", "call_1"),
             _tool_msg("3pm", "call_2"),
         ]
@@ -279,9 +279,9 @@ class TestTranslateRequestToolNameResolution:
             ],
             # No tool_call_signatures → unsigned
         )
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "user", "content": "check email"},
-            assistant_msg,
+            assistant_msg.to_input_dict(),
             _tool_msg("you have 3 emails", "call_1"),
         ]
         raw_contents, _ = _translate_request(msgs)
@@ -620,7 +620,7 @@ class TestTranslateAssistantPartsSignatures:
             ],
             tool_call_signatures=[sig],
         )
-        parts, text_fallback = _translate_assistant_parts(msg)
+        parts, text_fallback = _translate_assistant_parts(msg.to_input_dict())
         assert text_fallback is None
         fc_parts = [p for p in parts if p.function_call]
         assert len(fc_parts) == 1
@@ -633,7 +633,7 @@ class TestTranslateAssistantPartsSignatures:
             content="answer",
             thought_parts=[{"text": "thinking...", "thought": True, "thought_signature": sig}],
         )
-        parts, _ = _translate_assistant_parts(msg)
+        parts, _ = _translate_assistant_parts(msg.to_input_dict())
         thought_parts = [p for p in parts if p.thought]
         assert len(thought_parts) == 1
         assert thought_parts[0].thought_signature == sig
@@ -651,7 +651,9 @@ class TestTranslateAssistantPartsSignatures:
                 )
             ],
         )
-        parts, text_fallback = _translate_assistant_parts(msg, unsigned_tc_ids={"call_1"})
+        parts, text_fallback = _translate_assistant_parts(
+            msg.to_input_dict(), unsigned_tc_ids={"call_1"}
+        )
         fc_parts = [p for p in parts if p.function_call]
         assert len(fc_parts) == 0
         assert text_fallback is not None
@@ -670,14 +672,23 @@ class TestTranslateAssistantPartsSignatures:
                 )
             ],
         )
-        parts, text_fallback = _translate_assistant_parts(msg, unsigned_tc_ids={"call_1"})
+        parts, text_fallback = _translate_assistant_parts(
+            msg.to_input_dict(), unsigned_tc_ids={"call_1"}
+        )
         fc_parts = [p for p in parts if p.function_call]
         assert len(fc_parts) == 0
         assert text_fallback is not None
 
-    def test_signatures_survive_downcast_to_base_type(self):
-        """Signatures survive when GoogleMessage is round-tripped through
-        SRBenchChatCompletionMessage (the real-world failure scenario)."""
+    def test_signatures_survive_to_input_dict_roundtrip(self):
+        """Signatures survive across turns via the to_input_dict boundary.
+
+        The agent appends ``response.to_input_dict()`` to history each turn
+        (raw BaseModels never enter history). The next turn's provider reads
+        the TypedDict back via ``_translate_assistant_parts``. Bytes are
+        base64-encoded at the TypedDict boundary so that the dict is JSON-
+        serializable for traces/results; the provider decodes them back to
+        bytes before handing them to the Gemini SDK.
+        """
         sig = b"fc-sig-roundtrip"
         original = GoogleMessage(
             role="assistant",
@@ -692,19 +703,24 @@ class TestTranslateAssistantPartsSignatures:
             tool_call_signatures=[sig],
             thought_parts=[{"text": "hmm", "thought": True, "thought_signature": b"tp-sig"}],
         )
-        # Simulate round-trip: dump to dict → validate as base type
-        data = original.model_dump(mode="json")
-        restored = SRBenchChatCompletionMessage.model_validate(data)
-        assert not isinstance(restored, GoogleMessage)
+        input_msg = original.to_input_dict()
+        # Signatures are base64-encoded strings in the dict (JSON-friendly).
+        sigs = input_msg.get("tool_call_signatures")
+        assert sigs is not None
+        assert isinstance(sigs[0], str)
+        tps = input_msg.get("thought_parts")
+        assert tps is not None
+        assert isinstance(tps[0]["thought_signature"], str)
 
-        parts, text_fallback = _translate_assistant_parts(restored)
+        parts, text_fallback = _translate_assistant_parts(input_msg)
         assert text_fallback is None  # signatures present → no fallback
         fc_parts = [p for p in parts if p.function_call]
         assert len(fc_parts) == 1
-        assert fc_parts[0].thought_signature is not None
+        # Decoded back to original bytes.
+        assert fc_parts[0].thought_signature == sig
         thought_parts = [p for p in parts if p.thought]
         assert len(thought_parts) == 1
-        assert thought_parts[0].thought_signature is not None
+        assert thought_parts[0].thought_signature == b"tp-sig"
 
 
 class TestGoogleProviderComplete:

--- a/packages/srbench-llm/tests/providers/test_google.py
+++ b/packages/srbench-llm/tests/providers/test_google.py
@@ -684,10 +684,10 @@ class TestTranslateAssistantPartsSignatures:
 
         The agent appends ``response.to_input_dict()`` to history each turn
         (raw BaseModels never enter history). The next turn's provider reads
-        the TypedDict back via ``_translate_assistant_parts``. Bytes are
-        base64-encoded at the TypedDict boundary so that the dict is JSON-
-        serializable for traces/results; the provider decodes them back to
-        bytes before handing them to the Gemini SDK.
+        the TypedDict back via ``_translate_assistant_parts``. Signatures
+        stay as raw bytes in the dict — parent result/checkpoint models
+        strip them at JSON-serialization time so the bytes never need to
+        survive disk.
         """
         sig = b"fc-sig-roundtrip"
         original = GoogleMessage(
@@ -704,19 +704,18 @@ class TestTranslateAssistantPartsSignatures:
             thought_parts=[{"text": "hmm", "thought": True, "thought_signature": b"tp-sig"}],
         )
         input_msg = original.to_input_dict()
-        # Signatures are base64-encoded strings in the dict (JSON-friendly).
+        # Signatures stay as raw bytes in the in-memory dict.
         sigs = input_msg.get("tool_call_signatures")
         assert sigs is not None
-        assert isinstance(sigs[0], str)
+        assert sigs[0] == sig
         tps = input_msg.get("thought_parts")
         assert tps is not None
-        assert isinstance(tps[0]["thought_signature"], str)
+        assert tps[0]["thought_signature"] == b"tp-sig"
 
         parts, text_fallback = _translate_assistant_parts(input_msg)
         assert text_fallback is None  # signatures present → no fallback
         fc_parts = [p for p in parts if p.function_call]
         assert len(fc_parts) == 1
-        # Decoded back to original bytes.
         assert fc_parts[0].thought_signature == sig
         thought_parts = [p for p in parts if p.thought]
         assert len(thought_parts) == 1

--- a/packages/srbench-llm/tests/providers/test_google_integration.py
+++ b/packages/srbench-llm/tests/providers/test_google_integration.py
@@ -14,7 +14,7 @@ from pydantic import BaseModel
 from srbench_llm.client import SRBenchModelClient
 from srbench_llm.providers.google_genai import GoogleMessage, GoogleProvider
 from srbench_llm.tracing import LLMTrace
-from srbench_llm.types import SRBenchMessage
+from srbench_llm.types import SRBenchInputMessage
 
 MODEL = "gemini-2.5-flash"
 PROVIDER_MODEL = "gemini-2.5-flash"
@@ -172,9 +172,9 @@ class TestGoogleToolCalling:
         tc = msg1.tool_calls[0]
 
         # Turn 2: provide tool result (dict content) and get final answer
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -212,9 +212,9 @@ class TestGoogleToolCalling:
         assert msg1.tool_calls is not None
         tc = msg1.tool_calls[0]
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -250,9 +250,9 @@ class TestGoogleToolCalling:
         assert msg1.tool_calls is not None
         tc = msg1.tool_calls[0]
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -285,9 +285,9 @@ class TestGoogleToolCalling:
         assert msg1.tool_calls is not None
         tc = msg1.tool_calls[0]
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -350,9 +350,9 @@ class TestGemini3FlashToolCalling:
         assert isinstance(msg1, GoogleMessage)
         # (signature may be None on some models, but the field should exist)
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -386,9 +386,9 @@ class TestGemini3FlashToolCalling:
         assert msg1.tool_calls is not None
         tc = msg1.tool_calls[0]
 
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc.id,
@@ -440,9 +440,9 @@ class TestGemini3FlashToolCalling:
         tc1 = msg1.tool_calls[0]
 
         # Step 2: return first tool result
-        messages: list[SRBenchMessage] = [
+        messages: list[SRBenchInputMessage] = [
             {"role": "user", "content": "What's the weather and current time in Seattle?"},
-            msg1,
+            msg1.to_input_dict(),
             {
                 "role": "tool",
                 "tool_call_id": tc1.id,

--- a/packages/srbench-llm/tests/providers/test_openai.py
+++ b/packages/srbench-llm/tests/providers/test_openai.py
@@ -124,8 +124,8 @@ class TestToOpenAIMessages:
                 "role": "assistant",
                 "content": "x",
                 "thinking_blocks": [{"type": "thinking", "thinking": "...", "signature": "s"}],
-                "thought_parts": [{"text": "t", "thought_signature": "c2ln"}],
-                "tool_call_signatures": ["c2ln"],
+                "thought_parts": [{"text": "t", "thought_signature": b"sig"}],
+                "tool_call_signatures": [b"sig"],
                 "completion_info": {"id": "x", "model": "m", "finish_reason": "stop"},
             }
         ]

--- a/packages/srbench-llm/tests/providers/test_openai.py
+++ b/packages/srbench-llm/tests/providers/test_openai.py
@@ -23,7 +23,7 @@ from srbench_llm.tracing import LLMTrace
 from srbench_llm.types import (
     SRBenchChatCompletionInfo,
     SRBenchChatCompletionMessage,
-    SRBenchMessage,
+    SRBenchInputMessage,
 )
 
 
@@ -92,7 +92,7 @@ class TestToOpenAIMessage:
 
 class TestToOpenAIMessages:
     def test_sage_message_conversion(self):
-        msgs: list[SRBenchMessage] = [
+        msgs: list[SRBenchInputMessage] = [
             {"role": "system", "content": "be helpful"},
             {"role": "user", "content": "hi"},
         ]
@@ -105,13 +105,39 @@ class TestToOpenAIMessages:
 
     def test_assistant_with_completion_info_excluded(self):
         info = SRBenchChatCompletionInfo(id="x", model="m", finish_reason="stop")
-        msgs: list[SRBenchMessage] = [
-            SRBenchChatCompletionMessage(role="assistant", content="response", completion_info=info)
+        msgs: list[SRBenchInputMessage] = [
+            SRBenchChatCompletionMessage(
+                role="assistant", content="response", completion_info=info
+            ).to_input_dict()
         ]
         result = _to_openai_messages(msgs)
 
         assert "completion_info" not in result[0]
         assert result[0]["content"] == "response"
+
+    def test_extension_keys_stripped_for_sdk(self):
+        """SRBench extension keys (thinking_blocks, thought_parts,
+        tool_call_signatures, completion_info) must be stripped — the OpenAI
+        SDK rejects unknown keys."""
+        msgs: list[SRBenchInputMessage] = [
+            {
+                "role": "assistant",
+                "content": "x",
+                "thinking_blocks": [{"type": "thinking", "thinking": "...", "signature": "s"}],
+                "thought_parts": [{"text": "t", "thought_signature": "c2ln"}],
+                "tool_call_signatures": ["c2ln"],
+                "completion_info": {"id": "x", "model": "m", "finish_reason": "stop"},
+            }
+        ]
+        result = _to_openai_messages(msgs)
+        for forbidden in (
+            "thinking_blocks",
+            "thought_parts",
+            "tool_call_signatures",
+            "completion_info",
+        ):
+            assert forbidden not in result[0], f"extension key {forbidden!r} leaked into SDK input"
+        assert result[0]["content"] == "x"
 
 
 class TestPydanticToJsonSchema:

--- a/packages/srbench-llm/tests/test_client.py
+++ b/packages/srbench-llm/tests/test_client.py
@@ -10,7 +10,6 @@ from srbench_llm.tracing import tracer as _tracer
 from srbench_llm.types import (
     SRBenchChatCompletionInfo,
     SRBenchChatCompletionMessage,
-    SRBenchMessage,
 )
 
 

--- a/packages/srbench-llm/tests/test_tracing.py
+++ b/packages/srbench-llm/tests/test_tracing.py
@@ -9,7 +9,7 @@ from srbench_llm.tracing import LLMTrace, LLMTracer, SRBenchRequest, tracer
 from srbench_llm.types import (
     SRBenchChatCompletionInfo,
     SRBenchChatCompletionMessage,
-    SRBenchMessage,
+    SRBenchInputMessage,
 )
 
 
@@ -28,7 +28,7 @@ def _make_response_msg() -> SRBenchChatCompletionMessage:
 
 class TestLLMTrace:
     def test_build_with_srbench_types(self):
-        msgs: list[SRBenchMessage] = [{"role": "user", "content": "hi"}]
+        msgs: list[SRBenchInputMessage] = [{"role": "user", "content": "hi"}]
         trace = LLMTrace(
             srbench_request=SRBenchRequest(
                 model="gpt-4o",
@@ -93,7 +93,7 @@ class TestLLMTracer:
 class TestTraceSerialization:
     def test_save_and_load(self):
         t = LLMTracer()
-        msgs: list[SRBenchMessage] = [{"role": "user", "content": "hi"}]
+        msgs: list[SRBenchInputMessage] = [{"role": "user", "content": "hi"}]
         trace = LLMTrace(
             srbench_request=SRBenchRequest(
                 model="gpt-4o",

--- a/packages/srbench/srbench/benchmarks/base/types.py
+++ b/packages/srbench/srbench/benchmarks/base/types.py
@@ -56,12 +56,17 @@ def safe_serializer(cls: _T) -> _T:
     def _safe_model_dump_json(self: BaseModel, **kwargs: Any) -> str:
         try:
             return original(self, **kwargs)
-        except Exception:
+        except Exception as exc:
             _logger.debug(
-                "%s.model_dump_json failed; falling back to ftfy sanitization",
+                "%s.model_dump_json failed; falling back to ftfy sanitization: %s",
                 type(self).__name__,
+                exc,
             )
-            raw = self.model_dump()
+            # Use mode='json' so pydantic eagerly resolves iterators
+            # (TypedDict Iterable[...] fields become SerializationIterator
+            # objects under mode='python', which json.dumps(default=str)
+            # would then encode as their repr).
+            raw = self.model_dump(mode="json")
             _fix_strings(raw)
             return json.dumps(
                 raw,

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/assistant/calendar_assistant.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/assistant/calendar_assistant.py
@@ -1,6 +1,6 @@
 """Assistant agent for iTIP-style calendar scheduling."""
 
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from ...environment.actions import CALENDAR_TOOLS, EndConversation
 from ...types import CalendarAssistant, LabeledMeeting

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/calendar_base.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/calendar_base.py
@@ -5,12 +5,8 @@ from __future__ import annotations
 from typing import Any
 
 from openai.types.chat import ChatCompletionToolMessageParam
-from openai.types.chat.chat_completion_message_tool_call import (
-    ChatCompletionMessageToolCall,
-    Function,
-)
 from pydantic_core import to_json
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from ....shared.agent import BaseAgent, RetryException
 from ..environment.actions import (
@@ -122,22 +118,21 @@ class CalendarAgent(BaseAgent):
                 synthetic ``GetEmails`` call.
         """
         tool_call_id = str(len(self._messages))
-        tool_call_message = SRBenchChatCompletionMessage(
-            role="assistant",
-            tool_calls=[
-                ChatCompletionMessageToolCall(
-                    id=tool_call_id,
-                    type="function",
-                    function=Function(name=GetEmails.get_name(), arguments="{}"),
-                )
-            ],
+        self._messages.append(
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {"name": GetEmails.get_name(), "arguments": "{}"},
+                    }
+                ],
+            }
         )
-
         tool_message: ChatCompletionToolMessageParam = {
             "role": "tool",
             "tool_call_id": tool_call_id,
             "content": to_json(new_messages).decode(),
         }
-
-        self._messages.append(tool_call_message)
         self._messages.append(tool_message)

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/evaluate.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/evaluate.py
@@ -7,7 +7,6 @@ and discretion. The final due diligence score is the mean of all three.
 
 import json
 import logging
-from typing import Any
 
 from srbench_llm import SRBenchModelClient
 
@@ -22,12 +21,6 @@ from ...types import (
 from .judge import DueDiligenceJudge
 
 logger = logging.getLogger(__name__)
-
-
-def _tool_call_fn(tc: Any) -> tuple[str, str]:
-    """Extract (function name, function arguments JSON) from a tool call dict."""
-    fn = tc["function"]
-    return fn["name"], fn.get("arguments", "")
 
 
 def _format_agent_trace(execution_result: CalendarExecutionResult) -> str:
@@ -70,7 +63,9 @@ def _format_agent_trace(execution_result: CalendarExecutionResult) -> str:
             if content:
                 lines.append(f"[ASSISTANT] {content}")
             for tc in tool_calls:
-                fn_name, fn_args = _tool_call_fn(tc)
+                fn = tc["function"]  # ty: ignore[invalid-key]
+                fn_name = fn["name"]
+                fn_args = fn.get("arguments", "")
                 try:
                     args = json.loads(fn_args) if isinstance(fn_args, str) else fn_args
                     args_str = json.dumps(args, indent=2)

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/evaluate.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/evaluate.py
@@ -7,8 +7,9 @@ and discretion. The final due diligence score is the mean of all three.
 
 import json
 import logging
+from typing import Any
 
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from srbench.benchmarks.calendar_scheduling.evaluation.due_diligence.reasonable_agent import (
     CalendarReasonableAssistant,
@@ -21,6 +22,12 @@ from ...types import (
 from .judge import DueDiligenceJudge
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_call_fn(tc: Any) -> tuple[str, str]:
+    """Extract (function name, function arguments JSON) from a tool call dict."""
+    fn = tc["function"]
+    return fn["name"], fn.get("arguments", "")
 
 
 def _format_agent_trace(execution_result: CalendarExecutionResult) -> str:
@@ -53,16 +60,9 @@ def _format_agent_trace(execution_result: CalendarExecutionResult) -> str:
     # Format each message in the assistant's context
     lines.append("=== ASSISTANT TRACE ===")
     for message in execution_result.assistant_context:
-        if isinstance(message, SRBenchChatCompletionMessage):
-            role = message.role
-            content = message.content
-            tool_calls = message.tool_calls or []
-        elif isinstance(message, dict):
-            role = message.get("role", "")
-            content = message.get("content", "")
-            tool_calls = message.get("tool_calls") or []
-        else:
-            continue
+        role = message.get("role", "")
+        content = message.get("content", "")
+        tool_calls = message.get("tool_calls") or []
 
         if role == "system":
             lines.append(f"[SYSTEM] {content}")
@@ -70,8 +70,7 @@ def _format_agent_trace(execution_result: CalendarExecutionResult) -> str:
             if content:
                 lines.append(f"[ASSISTANT] {content}")
             for tc in tool_calls:
-                fn_name = tc.function.name  # ty: ignore[unresolved-attribute]
-                fn_args = tc.function.arguments  # ty: ignore[unresolved-attribute]
+                fn_name, fn_args = _tool_call_fn(tc)
                 try:
                     args = json.loads(fn_args) if isinstance(fn_args, str) else fn_args
                     args_str = json.dumps(args, indent=2)

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/reasonable_agent.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/due_diligence/reasonable_agent.py
@@ -90,11 +90,10 @@ class CalendarReasonableAssistant:
         """
         turns: list[CalendarTurn] = [[]]
         for msg in ctx:
-            tool_calls = getattr(msg, "tool_calls", None) or []
-            for tc in tool_calls:
-                fn = tc.function if hasattr(tc, "function") else tc.get("function", {})
-                name = fn.name if hasattr(fn, "name") else fn.get("name", "")
-                raw_args = fn.arguments if hasattr(fn, "arguments") else fn.get("arguments", "{}")
+            for tc in msg.get("tool_calls") or []:
+                fn = tc["function"]
+                name = fn["name"]
+                raw_args = fn.get("arguments", "{}")
                 if name == "GetEmails":
                     turns.append([])
                 elif name == "ListMeetings":

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/task_completion/meeting_scheduled.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/task_completion/meeting_scheduled.py
@@ -4,7 +4,7 @@ import logging
 from typing import Literal
 
 from pydantic import BaseModel, Field
-from srbench_llm import SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from ...environment.calendar import AgentCalendar
 from ...types import Meeting

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
@@ -9,7 +9,7 @@ from typing import Any, Literal
 
 from openai.types.chat import ChatCompletionFunctionToolParam, ChatCompletionMessageParam
 from pydantic import BaseModel, Field, computed_field, field_validator
-from srbench_llm import SRBenchMessage
+from srbench_llm import SRBenchInputMessage
 
 from ...shared.tool import Tool, ToolError
 from ..base import (
@@ -176,8 +176,8 @@ class CalendarExecutionResult(TaskExecutionResult[CalendarTask]):
     emails: list[Email] = Field(default_factory=list)
     final_assistant_calendar: list[Meeting] = Field(default_factory=list)
     final_requestor_calendar: list[Meeting] = Field(default_factory=list)
-    assistant_context: list[SRBenchMessage] = Field(default_factory=list)
-    requestor_context: list[SRBenchMessage] = Field(default_factory=list)
+    assistant_context: list[SRBenchInputMessage] = Field(default_factory=list)
+    requestor_context: list[SRBenchInputMessage] = Field(default_factory=list)
     assistant_tools: list[ChatCompletionFunctionToolParam] = Field(default_factory=list)
     requestor_tools: list[ChatCompletionFunctionToolParam] = Field(default_factory=list)
     max_rounds_reached: bool = False

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
@@ -8,8 +8,9 @@ from enum import Enum
 from typing import Any, Literal
 
 from openai.types.chat import ChatCompletionFunctionToolParam, ChatCompletionMessageParam
-from pydantic import BaseModel, Field, computed_field, field_validator
+from pydantic import BaseModel, Field, computed_field, field_serializer, field_validator
 from srbench_llm import SRBenchInputMessage
+from srbench_llm.types import strip_signatures_from_messages
 
 from ...shared.tool import Tool, ToolError
 from ..base import (
@@ -181,6 +182,10 @@ class CalendarExecutionResult(TaskExecutionResult[CalendarTask]):
     assistant_tools: list[ChatCompletionFunctionToolParam] = Field(default_factory=list)
     requestor_tools: list[ChatCompletionFunctionToolParam] = Field(default_factory=list)
     max_rounds_reached: bool = False
+
+    @field_serializer("assistant_context", "requestor_context", when_used="json")
+    def _strip_signatures(self, msgs: list[SRBenchInputMessage]) -> list[dict[str, Any]]:
+        return strip_signatures_from_messages(msgs)
 
 
 # ───────────────────────────────────────────────────────────────────

--- a/packages/srbench/srbench/benchmarks/marketplace/agents/marketplace_base.py
+++ b/packages/srbench/srbench/benchmarks/marketplace/agents/marketplace_base.py
@@ -2,12 +2,8 @@
 
 from typing import Any
 
-from openai.types.chat.chat_completion_message_tool_call import (
-    ChatCompletionMessageToolCall,
-    Function,
-)
 from pydantic_core import to_json
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from ....shared.agent import BaseAgent
 from ..environment.actions import GETMESSAGES_TOOL_NAME, MARKETPLACE_TOOLS
@@ -109,16 +105,16 @@ class MarketplaceAgent(BaseAgent):
         """
         tool_call_id = str(len(self._messages))
         self._messages.append(
-            SRBenchChatCompletionMessage(
-                role="assistant",
-                tool_calls=[
-                    ChatCompletionMessageToolCall(
-                        id=tool_call_id,
-                        type="function",
-                        function=Function(name=GETMESSAGES_TOOL_NAME, arguments="{}"),
-                    )
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {"name": GETMESSAGES_TOOL_NAME, "arguments": "{}"},
+                    }
                 ],
-            )
+            }
         )
         self._messages.append(
             {

--- a/packages/srbench/srbench/benchmarks/marketplace/evaluation/due_diligence/evaluate.py
+++ b/packages/srbench/srbench/benchmarks/marketplace/evaluation/due_diligence/evaluate.py
@@ -9,7 +9,6 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
 
 from srbench_llm import SRBenchModelClient
 
@@ -20,12 +19,6 @@ from .reasonable_agent import (
 )
 
 logger = logging.getLogger(__name__)
-
-
-def _tool_call_fn(tc: Any) -> tuple[str, str]:
-    """Extract (function name, function arguments JSON) from a tool call dict."""
-    fn = tc["function"]
-    return fn["name"], fn.get("arguments", "")
 
 
 def _format_buyer_trace(exec_result: MarketplaceExecutionResult) -> str:
@@ -59,7 +52,9 @@ def _format_buyer_trace(exec_result: MarketplaceExecutionResult) -> str:
             if content:
                 lines.append(f"[ASSISTANT] {content}")
             for tc in tool_calls:
-                fn_name, fn_args = _tool_call_fn(tc)
+                fn = tc["function"]  # ty: ignore[invalid-key]
+                fn_name = fn["name"]
+                fn_args = fn.get("arguments", "")
                 try:
                     args = json.loads(fn_args) if isinstance(fn_args, str) else fn_args
                     args_str = json.dumps(args, indent=2)

--- a/packages/srbench/srbench/benchmarks/marketplace/evaluation/due_diligence/evaluate.py
+++ b/packages/srbench/srbench/benchmarks/marketplace/evaluation/due_diligence/evaluate.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any
 
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchModelClient
+from srbench_llm import SRBenchModelClient
 
 from ...types import MarketplaceDueDiligenceEvaluation, MarketplaceExecutionResult
 from .judge import MarketplaceDueDiligenceJudge, MarketplaceDueDiligenceJudgement, RatingLevel
@@ -19,6 +20,12 @@ from .reasonable_agent import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _tool_call_fn(tc: Any) -> tuple[str, str]:
+    """Extract (function name, function arguments JSON) from a tool call dict."""
+    fn = tc["function"]
+    return fn["name"], fn.get("arguments", "")
 
 
 def _format_buyer_trace(exec_result: MarketplaceExecutionResult) -> str:
@@ -42,16 +49,9 @@ def _format_buyer_trace(exec_result: MarketplaceExecutionResult) -> str:
     # Assistant trace
     lines.append("=== ASSISTANT TRACE ===")
     for message in exec_result.buyer_context:
-        if isinstance(message, SRBenchChatCompletionMessage):
-            role = message.role
-            content = message.content
-            tool_calls = message.tool_calls or []
-        elif isinstance(message, dict):
-            role = message.get("role", "")
-            content = message.get("content", "")
-            tool_calls = message.get("tool_calls") or []
-        else:
-            continue
+        role = message.get("role", "")
+        content = message.get("content", "")
+        tool_calls = message.get("tool_calls") or []
 
         if role == "system":
             lines.append(f"[SYSTEM] {content}")
@@ -59,8 +59,7 @@ def _format_buyer_trace(exec_result: MarketplaceExecutionResult) -> str:
             if content:
                 lines.append(f"[ASSISTANT] {content}")
             for tc in tool_calls:
-                fn_name = tc.function.name  # ty: ignore[unresolved-attribute]
-                fn_args = tc.function.arguments  # ty: ignore[unresolved-attribute]
+                fn_name, fn_args = _tool_call_fn(tc)
                 try:
                     args = json.loads(fn_args) if isinstance(fn_args, str) else fn_args
                     args_str = json.dumps(args, indent=2)

--- a/packages/srbench/srbench/benchmarks/marketplace/types.py
+++ b/packages/srbench/srbench/benchmarks/marketplace/types.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from typing import Any, Literal
 
 from pydantic import BaseModel, Field, computed_field
-from srbench_llm import SRBenchMessage
+from srbench_llm import SRBenchInputMessage
 
 from ...shared.tool import Tool, ToolError
 from ..base import (
@@ -113,8 +113,8 @@ class MarketplaceExecutionResult(TaskExecutionResult[MarketplaceTask]):
     offers: list[OfferRecord] = Field(default_factory=list)
     action_trace: list[ActionTrace] = Field(default_factory=list)
     invalid_actions: int = 0
-    buyer_context: list[SRBenchMessage] = Field(default_factory=list)
-    seller_context: list[SRBenchMessage] = Field(default_factory=list)
+    buyer_context: list[SRBenchInputMessage] = Field(default_factory=list)
+    seller_context: list[SRBenchInputMessage] = Field(default_factory=list)
 
     @property
     def seller_surplus(self) -> float:

--- a/packages/srbench/srbench/benchmarks/marketplace/types.py
+++ b/packages/srbench/srbench/benchmarks/marketplace/types.py
@@ -5,8 +5,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Literal
 
-from pydantic import BaseModel, Field, computed_field
+from pydantic import BaseModel, Field, computed_field, field_serializer
 from srbench_llm import SRBenchInputMessage
+from srbench_llm.types import strip_signatures_from_messages
 
 from ...shared.tool import Tool, ToolError
 from ..base import (
@@ -115,6 +116,10 @@ class MarketplaceExecutionResult(TaskExecutionResult[MarketplaceTask]):
     invalid_actions: int = 0
     buyer_context: list[SRBenchInputMessage] = Field(default_factory=list)
     seller_context: list[SRBenchInputMessage] = Field(default_factory=list)
+
+    @field_serializer("buyer_context", "seller_context", when_used="json")
+    def _strip_signatures(self, msgs: list[SRBenchInputMessage]) -> list[dict[str, Any]]:
+        return strip_signatures_from_messages(msgs)
 
     @property
     def seller_surplus(self) -> float:

--- a/packages/srbench/srbench/shared/agent.py
+++ b/packages/srbench/srbench/shared/agent.py
@@ -24,10 +24,9 @@ from typing import Any
 from openai.types.chat import ChatCompletionFunctionToolParam, ChatCompletionToolChoiceOptionParam
 from openai.types.chat.chat_completion_message_tool_call import (
     ChatCompletionMessageToolCall,
-    Function,
 )
 from pydantic import ValidationError
-from srbench_llm import SRBenchChatCompletionMessage, SRBenchMessage, SRBenchModelClient
+from srbench_llm import SRBenchInputMessage, SRBenchModelClient
 
 from .tool import Tool
 
@@ -108,7 +107,7 @@ class BaseAgent:
         self._model = model
         self._model_client = model_client
         self._prompt_label = prompt_label
-        self._messages: list[SRBenchMessage] = []
+        self._messages: list[SRBenchInputMessage] = []
         self._explicit_cot = explicit_cot
         self._temperature = temperature
         self._tool_choice = tool_choice
@@ -122,7 +121,7 @@ class BaseAgent:
         ]
 
     @property
-    def messages(self) -> list[SRBenchMessage]:
+    def messages(self) -> list[SRBenchInputMessage]:
         """Return the current message history (read-only view).
 
         Returns:
@@ -156,15 +155,13 @@ class BaseAgent:
             ValueError: If the last message is not an assistant tool-call message.
         """
         last = self._messages[-1] if self._messages else None
-        # Support both dicts (TypedDicts) and pydantic models (SRBenchChatCompletionMessage)
-        tc = last.get("tool_calls") if isinstance(last, dict) else getattr(last, "tool_calls", None)
+        tc = last.get("tool_calls") if last else None
         if not tc:
             raise ValueError("Expected previous message to be an assistant tool-call message")
         tool_calls = list(tc)
         if len(tool_calls) != 1:
             raise ValueError("Can only call add_tool_call_result after exactly one tool call")
-        tc0 = tool_calls[0]
-        tool_call_id = tc0["id"] if isinstance(tc0, dict) else tc0.id  # ty: ignore[unresolved-attribute]
+        tool_call_id = tool_calls[0]["id"]
         self._messages.append(
             {
                 "role": "tool",
@@ -185,19 +182,19 @@ class BaseAgent:
         """
         tool_call_id = str(len(self._messages))
         self._messages.append(
-            SRBenchChatCompletionMessage(
-                role="assistant",
-                tool_calls=[
-                    ChatCompletionMessageToolCall(
-                        id=tool_call_id,
-                        type="function",
-                        function=Function(
-                            name=action.get_name(),
-                            arguments=action.model_dump_json(),
-                        ),
-                    )
+            {
+                "role": "assistant",
+                "tool_calls": [
+                    {
+                        "id": tool_call_id,
+                        "type": "function",
+                        "function": {
+                            "name": action.get_name(),
+                            "arguments": action.model_dump_json(),
+                        },
+                    }
                 ],
-            )
+            }
         )
         self._messages.append(
             {
@@ -255,7 +252,7 @@ class BaseAgent:
     # Explicit chain-of-thought
     # ------------------------------------------------------------------ #
 
-    async def _generate_cot_reasoning(self, messages: list[SRBenchMessage]) -> str:
+    async def _generate_cot_reasoning(self, messages: list[SRBenchInputMessage]) -> str:
         """Generate chain-of-thought reasoning before a tool call.
 
         Makes a separate LLM call without tools to produce internal reasoning,
@@ -323,12 +320,7 @@ class BaseAgent:
             if self._explicit_cot:
                 cot_thinking = await self._generate_cot_reasoning(messages)
                 if cot_thinking:
-                    messages.append(
-                        SRBenchChatCompletionMessage(
-                            role="assistant",
-                            content=cot_thinking,
-                        )
-                    )
+                    messages.append({"role": "assistant", "content": cot_thinking})
 
             # Call the LLM
             from srbench_llm.concurrency import prompt_label
@@ -388,19 +380,12 @@ class BaseAgent:
 
                 # Successfully parsed -- commit to canonical history
                 if cot_thinking:
-                    self._messages.append(
-                        SRBenchChatCompletionMessage(role="assistant", content=cot_thinking)
-                    )
+                    self._messages.append({"role": "assistant", "content": cot_thinking})
 
                 # Keep the original message so provider-specific fields
                 # (e.g. thought_signature for Gemini 3+) are preserved.
                 self._messages.append(
-                    message.model_copy(
-                        update={
-                            "tool_calls": [tool_call],
-                            "completion_info": None,
-                        }
-                    )
+                    message.model_copy(update={"tool_calls": [tool_call]}).to_input_dict()
                 )
 
                 return parsed_tool_call
@@ -410,12 +395,7 @@ class BaseAgent:
 
                 if not tool_calls:
                     # No tool calls -- use plain assistant/user message for retry
-                    messages.append(
-                        SRBenchChatCompletionMessage(
-                            role="assistant",
-                            content=message.content,
-                        )
-                    )
+                    messages.append({"role": "assistant", "content": message.content})
                     messages.append(
                         {"role": "user", "content": self.on_retry_no_tool_calls()},
                     )
@@ -423,7 +403,7 @@ class BaseAgent:
                     # Invalid tool calls -- echo them back with error details.
                     # Preserve the original message to keep provider-specific
                     # fields (e.g. thought_signature).
-                    messages.append(message.model_copy(update={"completion_info": None}))
+                    messages.append(message.to_input_dict())
                     for tc in tool_calls:
                         messages.append(
                             {
@@ -453,7 +433,7 @@ class BaseAgent:
         """
         from srbench_llm.concurrency import prompt_label
 
-        messages: list[SRBenchMessage] = [*self._messages, {"role": "user", "content": prompt}]
+        messages: list[SRBenchInputMessage] = [*self._messages, {"role": "user", "content": prompt}]
         token = prompt_label.set(self._prompt_label)
         try:
             response = await self._model_client.acomplete(


### PR DESCRIPTION
`SRBenchMessage` was a `Union[BaseModel, TypedDict]` alias annotated with a `PlainValidator`/`PlainSerializer` hack to paper over the type mismatch. Lists annotated `list[SRBenchMessage]` mixed both kinds at runtime, forcing every provider into `isinstance` branching and breaking type narrowing for ty/pyright.

Replace with strict separation:

- Input side: `SRBenchInputMessage`, a `SkipValidation`-wrapped TypedDict union of system/user/`SRBenchAssistantMessageParam`/tool. `SRBenchAssistantMessageParam` extends `ChatCompletionAssistantMessageParam` with optional extension keys (`completion_info`, `thinking_blocks`, `thought_parts`, `tool_call_signatures`). `SkipValidation` is essential: OpenAI's `TypedDicts` declare `tool_calls` as `Iterable[...]`, which pydantic eagerly validates into a single-consume `ValidatorIterator` that gets exhausted by the first reader.

- Output side: `SRBenchChatCompletionMessage` (`BaseModel`) stays as the response type. Field serializers shape `model_dump` output into a `SRBenchAssistantMessageParam` (excludes `completion_info`, base64-encodes Gemini signature bytes). The thin typed shim `to_input_dict()` just narrows the return type.

Provider translation paths (`_translate_messages`, `_to_openai_messages`, `_translate_request`) iterate dicts directly — no more `isinstance` branches. Each provider's bytes-typed signatures round-trip via `encode_signature` / `decode_signature` helpers.

Other touched paths:
- Agents (`BaseAgent`, calendar/marketplace bases, privacy-judge): build assistant history as plain dicts; remove the `BaseModel`-then-convert antipattern.
- `safe_serializer` fallback uses `model_dump(mode='json')` so it doesn't leak `SerializationIterator` repr strings if the rust serializer fails.
- Calendar and marketplace due-diligence evaluators drop the dead `isinstance(message, SRBenchChatCompletionMessage)` branches and read `tool_calls` via dict access (the `reasonable_agent` previously silently treated dicts as having no tool_calls).
- Result/trace types (`LLMTrace`, `CalendarExecutionResult`, `MarketplaceExecutionResult`) use `list[SRBenchInputMessage]` without per-field `SkipValidation` since the alias carries the annotation.

Verified end-to-end: srbench-llm unit tests all pass (177). srbench tests have the same 8 pre-existing failures as main (verified via git stash). Smoke benchmarks ran cleanly for gpt-4.1, gpt-5.4, claude-sonnet-4-6, and gemini-3-flash-preview across calendar + marketplace.

## To test:

Unit and integration tests:
```bash
uv sync
# export OPENAI_API_KEY, ANTHROPIC_API_KEY, and GEMINI_API_KEY
uv run --directory packages/srbench-llm pytest -k "not azure"
```

End-to-end smoke test:
```bash
# export OPENAI_API_KEY
uv run srbench experiment experiments/smoke --set model=openai/gpt-4.1
```

---

**PR Checklist (do not remove):**

- [ ] I linked this PR to an issue
- [x] I included code instructions on how to test
