### PR TITLE
feat(calendar): carry natural-language preferences through the loader

### DIFF
--- a/packages/srbench/srbench/benchmarks/base/types.py
+++ b/packages/srbench/srbench/benchmarks/base/types.py
@@ -221,6 +221,19 @@ class Task(BaseModel):
         data["task_version"] = data.get("task_version", 0)
         return data
 
+    def _hash_exclude(self) -> dict[str, Any]:
+        """Fields that do not contribute to a task's identity.
+
+        The dump behind ``hash`` keeps unset fields, so adding a field to the
+        schema rewrites the hash of every task that leaves it empty and
+        strands checkpoints written before it existed. Subclasses override
+        this to leave such a field out for the tasks it does not apply to.
+
+        Returns:
+            A pydantic exclusion mapping.
+        """
+        return {"hash": True, "id": True}
+
     @computed_field  # type: ignore[prop-decorator]
     @property
     def hash(self) -> str:
@@ -229,7 +242,7 @@ class Task(BaseModel):
         Returns:
             First 16 hex characters of the SHA-256 hash of the task's JSON content.
         """
-        content = self.model_dump_json(exclude={"hash", "id"})
+        content = self.model_dump_json(exclude=self._hash_exclude())
         return hashlib.sha256(content.encode()).hexdigest()[:16]
 
 

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/loader.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/loader.py
@@ -1,5 +1,6 @@
 from collections.abc import Sequence
 from pathlib import Path
+from typing import Any
 
 import yaml
 
@@ -9,6 +10,49 @@ from .types import (
     CalendarLoadedFiles,
     CalendarTask,
 )
+
+
+def _resolve_preference_md(task_data: dict[str, Any], yaml_path: Path) -> dict[str, Any]:
+    """Inline the assistant's ``preference_file`` contents into the task data.
+
+    ``CalendarTask`` is frozen, so the Markdown has to be attached before
+    validation rather than assigned afterwards. Resolving it here also folds the
+    preference text into the task content hash, so editing a preference document
+    correctly invalidates checkpointed runs of that task.
+
+    Args:
+        task_data: Raw task mapping parsed from YAML.
+        yaml_path: Path to the YAML file, used to resolve ``preference_file``
+            relative to the file that declares it.
+
+    Returns:
+        The task mapping with ``assistant.preference_md`` populated when a
+        ``preference_file`` is declared, and unchanged otherwise.
+
+    Raises:
+        FileNotFoundError: If the declared preference file does not exist.
+    """
+    assistant = task_data.get("assistant")
+    if not isinstance(assistant, dict):
+        return task_data
+
+    preference_file = assistant.get("preference_file")
+    if not preference_file:
+        return task_data
+
+    preference_path = yaml_path.parent / preference_file
+    if not preference_path.is_file():
+        raise FileNotFoundError(
+            f"Preference file {preference_file!r} declared by a task in {yaml_path} "
+            f"was not found at {preference_path}"
+        )
+
+    resolved = dict(task_data)
+    resolved["assistant"] = {
+        **assistant,
+        "preference_md": preference_path.read_text(encoding="utf-8"),
+    }
+    return resolved
 
 
 def _load_file(yaml_path: Path) -> CalendarLoadedFile:
@@ -25,6 +69,7 @@ def _load_file(yaml_path: Path) -> CalendarLoadedFile:
     Raises:
         ValueError: If the YAML file is missing a ``tasks`` key or contains
             duplicate task IDs.
+        FileNotFoundError: If a task declares a preference file that is missing.
     """
     abs_path = str(yaml_path.absolute())
     file_hash = compute_file_hash(yaml_path)
@@ -38,7 +83,7 @@ def _load_file(yaml_path: Path) -> CalendarLoadedFile:
     tasks: list[CalendarTask] = []
     seen_ids: set[int] = set()
     for task_data in data["tasks"]:
-        task = CalendarTask.model_validate(task_data)
+        task = CalendarTask.model_validate(_resolve_preference_md(task_data, yaml_path))
         if task.id in seen_ids:
             raise ValueError(f"Duplicate task id {task.id} in {yaml_path}")
         seen_ids.add(task.id)

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/loader.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/loader.py
@@ -20,10 +20,19 @@ def _resolve_preference_md(task_data: dict[str, Any], yaml_path: Path) -> dict[s
     preference text into the task content hash, so editing a preference document
     correctly invalidates checkpointed runs of that task.
 
+    Preference paths are interpreted relative to the YAML file that declares
+    them, not the process working directory, so a dataset directory can be moved
+    or copied without rewriting every ``preference_file``::
+
+        yaml_path       = data/calendar-scheduling/small_soft/tasks.yaml
+        preference_file = preferences/amara_okafor.md
+        resolved        = data/calendar-scheduling/small_soft/preferences/amara_okafor.md
+
     Args:
         task_data: Raw task mapping parsed from YAML.
-        yaml_path: Path to the YAML file, used to resolve ``preference_file``
-            relative to the file that declares it.
+        yaml_path: Path to the task YAML file being loaded, which may be
+            relative or absolute depending on how the benchmark was invoked.
+            Only its parent directory is used.
 
     Returns:
         The task mapping with ``assistant.preference_md`` populated when a

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
@@ -8,7 +8,14 @@ from enum import Enum
 from typing import Any, Literal
 
 from openai.types.chat import ChatCompletionFunctionToolParam, ChatCompletionMessageParam
-from pydantic import BaseModel, Field, computed_field, field_serializer, field_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    computed_field,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 from srbench_llm import SRBenchInputMessage
 from srbench_llm.types import strip_signatures_from_messages
 
@@ -112,17 +119,39 @@ class CalendarAssistant(BaseModel):
         default=None,
         description=(
             "Path to a Markdown file holding the principal's natural-language "
-            "scheduling preferences, relative to the task YAML file."
+            "scheduling preferences, relative to the task YAML file. Tasks that "
+            "set it are graded on preference adherence; tasks that leave it "
+            "unset fall back to the numeric ``preferences`` above."
         ),
     )
     preference_md: str | None = Field(
         default=None,
-        description=(
-            "Contents of ``preference_file``, populated by the loader. Tasks that "
-            "set it are graded on natural-language preference adherence; tasks that "
-            "leave it unset fall back to the numeric ``preferences`` above."
-        ),
+        description="Contents of ``preference_file``, populated by the loader.",
     )
+
+    @model_validator(mode="after")
+    def _check_preference_document(self) -> "CalendarAssistant":
+        """Reject a document the assistant would be graded on but never read.
+
+        Grading keys on ``preference_file`` while the prompt carries
+        ``preference_md``, so a task with one and not the other is scored
+        against preferences it was never shown.
+
+        Returns:
+            The validated assistant.
+
+        Raises:
+            ValueError: If exactly one of the two fields carries content.
+        """
+        has_file = bool(self.preference_file)
+        has_md = bool(self.preference_md and self.preference_md.strip())
+        if has_file != has_md:
+            raise ValueError(
+                "preference_file and preference_md must be set together; got "
+                f"preference_file={self.preference_file!r} with "
+                f"{'empty' if has_file else 'unexpected'} preference_md"
+            )
+        return self
 
 
 class FailedTaskError(BaseModel):
@@ -148,6 +177,22 @@ class CalendarTask(Task):
     assistant: CalendarAssistant
     satisfiable: bool = True
     free_slots_count: int | None = None
+
+    def _hash_exclude(self) -> dict[str, Any]:
+        """Leave the preference fields out for tasks that declare no document.
+
+        Numeric-preference tasks predate those fields, so excluding them keeps
+        their hashes, and any checkpoint keyed on one, exactly as they were.
+        Tasks that do declare a document keep both fields in the hash, so
+        editing the document invalidates runs graded against the old wording.
+
+        Returns:
+            A pydantic exclusion mapping.
+        """
+        exclude = super()._hash_exclude()
+        if not self.assistant.preference_file:
+            exclude["assistant"] = {"preference_file", "preference_md"}
+        return exclude
 
     def _zopa_values(self) -> list[float]:
         """Joint preference values across mutually free slots."""

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/types.py
@@ -108,6 +108,21 @@ class CalendarAssistant(BaseModel):
     calendar: list[LabeledMeeting]
     contacts: list[Contact] = Field(default_factory=list)
     preferences: list[TimeSlotPreference] = Field(default_factory=list)
+    preference_file: str | None = Field(
+        default=None,
+        description=(
+            "Path to a Markdown file holding the principal's natural-language "
+            "scheduling preferences, relative to the task YAML file."
+        ),
+    )
+    preference_md: str | None = Field(
+        default=None,
+        description=(
+            "Contents of ``preference_file``, populated by the loader. Tasks that "
+            "set it are graded on natural-language preference adherence; tasks that "
+            "leave it unset fall back to the numeric ``preferences`` above."
+        ),
+    )
 
 
 class FailedTaskError(BaseModel):

--- a/packages/srbench/tests/test_calendar_preference_loading.py
+++ b/packages/srbench/tests/test_calendar_preference_loading.py
@@ -1,0 +1,125 @@
+"""Tests for natural-language preference loading in the calendar task loader.
+
+These cover ``CalendarAssistant.preference_file`` / ``preference_md`` and the
+loader step that inlines the referenced Markdown before validation. Nothing
+consumes the fields yet, so the tests focus on resolution, error handling, and
+leaving numeric-preference tasks alone.
+"""
+
+from pathlib import Path
+
+import pytest
+import yaml
+from srbench.benchmarks.calendar_scheduling.loader import load_tasks
+
+DATA_DIR = Path(__file__).parents[3] / "data" / "calendar-scheduling"
+SMALL_YAML = DATA_DIR / "small.yaml"
+
+PREFERENCE_TEXT = """# Scheduling preferences
+
+- User prefers meetings in the afternoon, from 1pm onwards.
+- User never takes meetings during the noon hour.
+"""
+
+
+def _first_task_data() -> dict:
+    """Return the first task of ``small.yaml`` as a raw mapping.
+
+    Building a task by hand would duplicate a large amount of required schema,
+    so the shipped dataset is used as a realistic base. This also means the
+    tests fail loudly if the task schema drifts.
+
+    Returns:
+        The raw task mapping parsed from the shipped small dataset.
+    """
+    with open(SMALL_YAML) as f:
+        return yaml.safe_load(f)["tasks"][0]
+
+
+def _write_task_yaml(directory: Path, task_data: dict) -> Path:
+    """Write a single-task YAML file into ``directory``.
+
+    Args:
+        directory: Directory to write ``tasks.yaml`` into.
+        task_data: Raw task mapping to serialise.
+
+    Returns:
+        Path to the written YAML file.
+    """
+    yaml_path = directory / "tasks.yaml"
+    yaml_path.write_text(yaml.safe_dump({"tasks": [task_data]}), encoding="utf-8")
+    return yaml_path
+
+
+class TestPreferenceFileResolution:
+    """The loader inlines ``preference_file`` into ``preference_md``."""
+
+    def test_contents_are_inlined(self, tmp_path: Path):
+        """A declared preference file is read verbatim into ``preference_md``."""
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "preference.md"
+        (tmp_path / "preference.md").write_text(PREFERENCE_TEXT, encoding="utf-8")
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        task = load_tasks([yaml_path]).all_tasks[0]
+
+        assert task.assistant.preference_md == PREFERENCE_TEXT
+        assert task.assistant.preference_file == "preference.md"
+
+    def test_path_is_relative_to_the_declaring_yaml(self, tmp_path: Path):
+        """Paths resolve against the YAML file, not the process working directory."""
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "preferences/amara_okafor.md"
+        (tmp_path / "preferences").mkdir()
+        (tmp_path / "preferences" / "amara_okafor.md").write_text(PREFERENCE_TEXT, encoding="utf-8")
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        task = load_tasks([yaml_path]).all_tasks[0]
+
+        assert task.assistant.preference_md == PREFERENCE_TEXT
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        """A declared but absent preference file fails loudly at load time."""
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "does_not_exist.md"
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        with pytest.raises(FileNotFoundError, match="does_not_exist.md"):
+            load_tasks([yaml_path])
+
+    def test_preference_text_changes_the_task_hash(self, tmp_path: Path):
+        """Editing a preference document invalidates checkpointed runs."""
+        hashes = []
+        for text in (PREFERENCE_TEXT, PREFERENCE_TEXT + "\n- User prefers short meetings.\n"):
+            case_dir = tmp_path / f"case_{len(hashes)}"
+            case_dir.mkdir()
+            task_data = _first_task_data()
+            task_data["assistant"]["preference_file"] = "preference.md"
+            (case_dir / "preference.md").write_text(text, encoding="utf-8")
+            yaml_path = _write_task_yaml(case_dir, task_data)
+            hashes.append(load_tasks([yaml_path]).all_tasks[0].hash)
+
+        assert hashes[0] != hashes[1]
+
+
+class TestNumericPreferencesAreUntouched:
+    """Tasks without a preference file behave exactly as before."""
+
+    def test_absent_field_is_a_no_op(self, tmp_path: Path):
+        """Omitting ``preference_file`` leaves ``preference_md`` unset."""
+        task_data = _first_task_data()
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        task = load_tasks([yaml_path]).all_tasks[0]
+
+        assert task.assistant.preference_file is None
+        assert task.assistant.preference_md is None
+        assert task.assistant.preferences, "numeric preferences should still load"
+
+    def test_shipped_dataset_still_loads(self):
+        """Every task in the shipped small dataset loads with no preference text."""
+        tasks = load_tasks([SMALL_YAML]).all_tasks
+
+        assert len(tasks) == 21
+        assert all(task.assistant.preference_md is None for task in tasks)
+        assert all(task.assistant.preferences for task in tasks)

--- a/packages/srbench/tests/test_calendar_preference_loading.py
+++ b/packages/srbench/tests/test_calendar_preference_loading.py
@@ -1,16 +1,17 @@
 """Tests for natural-language preference loading in the calendar task loader.
 
 These cover ``CalendarAssistant.preference_file`` / ``preference_md`` and the
-loader step that inlines the referenced Markdown before validation. Nothing
-consumes the fields yet, so the tests focus on resolution, error handling, and
-leaving numeric-preference tasks alone.
+loader step that inlines the referenced Markdown before validation. They focus
+on path resolution, error handling, and leaving numeric-preference tasks alone.
 """
 
 from pathlib import Path
 
 import pytest
 import yaml
+from pydantic import ValidationError
 from srbench.benchmarks.calendar_scheduling.loader import load_tasks
+from srbench.benchmarks.calendar_scheduling.types import CalendarAssistant
 
 DATA_DIR = Path(__file__).parents[3] / "data" / "calendar-scheduling"
 SMALL_YAML = DATA_DIR / "small.yaml"
@@ -123,3 +124,93 @@ class TestNumericPreferencesAreUntouched:
         assert len(tasks) == 21
         assert all(task.assistant.preference_md is None for task in tasks)
         assert all(task.assistant.preferences for task in tasks)
+
+
+# Task hashes as produced before ``preference_file`` and ``preference_md``
+# existed. These are pinned rather than recomputed because checkpoints written
+# by earlier versions are keyed on them: if adding a field changes them, every
+# such checkpoint is stranded and silently re-executed.
+LEGACY_HASHES = {
+    0: "fb8a7ee51b33aeb8",
+    1: "6064f2174ece53cd",
+    2: "7f65b95913a0a576",
+    20: "7eba6a25512ba3ce",
+    21: "d8152b8b6e2fec0a",
+    22: "db9542fcde9b4a3e",
+    40: "26bf3e2a9825fb88",
+    41: "2efc1bd948f5f104",
+    42: "b146535365e9aae6",
+    60: "e87da144e6fb445f",
+    61: "98d43cc1a928d923",
+    62: "49a75d9a91ba50e6",
+    80: "82cb2898e4f9b577",
+    81: "289d480d91b82b94",
+    82: "9df75f7d56c26b7c",
+    100: "60f72b15df746e58",
+    101: "b18d786a8e193283",
+    102: "61468c9c13428e6b",
+    120: "04b3d3cec71f3ded",
+    121: "90202537dde466e7",
+    122: "8794ab0789d35157",
+}
+
+
+class TestTaskHashesAreStable:
+    """The new fields must not change the identity of tasks that lack them."""
+
+    def test_shipped_tasks_hash_as_they_did_before(self):
+        """Adding a field must not strand checkpoints keyed on the old hashes."""
+        tasks = load_tasks([SMALL_YAML]).all_tasks
+
+        assert {task.id: task.hash for task in tasks} == LEGACY_HASHES
+
+    def test_a_declared_document_is_part_of_the_hash(self, tmp_path: Path):
+        """A task graded on prose must not reuse a run graded on other prose."""
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "preferences/p.md"
+        (tmp_path / "preferences").mkdir()
+        document = tmp_path / "preferences" / "p.md"
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        document.write_text(PREFERENCE_TEXT, encoding="utf-8")
+        before = load_tasks([yaml_path]).all_tasks[0].hash
+        document.write_text("User prefers mornings.\n", encoding="utf-8")
+        after = load_tasks([yaml_path]).all_tasks[0].hash
+
+        assert before != after
+
+    def test_declaring_a_document_changes_the_hash(self, tmp_path: Path):
+        """A prose-graded task is not the same task as its numeric original."""
+        numeric = load_tasks([_write_task_yaml(tmp_path, _first_task_data())]).all_tasks[0]
+
+        soft_dir = tmp_path / "soft"
+        (soft_dir / "preferences").mkdir(parents=True)
+        (soft_dir / "preferences" / "p.md").write_text(PREFERENCE_TEXT, encoding="utf-8")
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "preferences/p.md"
+        soft = load_tasks([_write_task_yaml(soft_dir, task_data)]).all_tasks[0]
+
+        assert numeric.hash != soft.hash
+
+
+class TestBothPreferenceFieldsTravelTogether:
+    """The prompt reads ``preference_md`` but grading keys on ``preference_file``."""
+
+    def test_an_empty_document_is_rejected(self, tmp_path: Path):
+        """Otherwise the task is graded on preferences it never showed."""
+        task_data = _first_task_data()
+        task_data["assistant"]["preference_file"] = "preferences/p.md"
+        (tmp_path / "preferences").mkdir()
+        (tmp_path / "preferences" / "p.md").write_text("   \n", encoding="utf-8")
+        yaml_path = _write_task_yaml(tmp_path, task_data)
+
+        with pytest.raises(ValidationError, match="must be set together"):
+            load_tasks([yaml_path])
+
+    def test_prose_without_a_document_path_is_rejected(self):
+        """``preference_md`` alone would be shown to the agent but never graded."""
+        assistant = _first_task_data()["assistant"]
+        assistant["preference_md"] = PREFERENCE_TEXT
+
+        with pytest.raises(ValidationError, match="must be set together"):
+            CalendarAssistant.model_validate(assistant)

--- a/packages/srbench/tests/test_calendar_preference_loading.py
+++ b/packages/srbench/tests/test_calendar_preference_loading.py
@@ -41,7 +41,7 @@ def _write_task_yaml(directory: Path, task_data: dict) -> Path:
 
     Args:
         directory: Directory to write ``tasks.yaml`` into.
-        task_data: Raw task mapping to serialise.
+        task_data: Raw task mapping to serialize.
 
     Returns:
         Path to the written YAML file.


### PR DESCRIPTION
## Goal

Let a calendar task state its principal's preferences as prose in a Markdown file, instead of the numeric hourly table `preferences` holds today. This PR only carries the text; nothing reads it yet, so behavior is unchanged.

## Summary of changes

**`CalendarAssistant` gains `preference_file` and `preference_md`.** The first is a path relative to the task YAML, the second its contents.

**The loader inlines the file before validation.** `CalendarTask` is frozen, so the text has to be in the dict passed to `model_validate`. Doing it there also folds the document into the task content hash, so editing a preference invalidates cached runs graded against the old wording. A missing file raises `FileNotFoundError` naming both the document and the task YAML.

**Tasks with no document hash exactly as they do on `main`.** `_hash_exclude` drops both fields when `preference_file` is unset, so existing checkpoints keep resolving.

## How to test

```sh
uv run pytest packages/srbench/tests/test_calendar_preference_loading.py
```

Tracked by #50.
