### PR TITLE
feat(calendar): add the preference adherence scoring engine

### DIFF
--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/__init__.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/__init__.py
@@ -1,0 +1,43 @@
+"""Programmatic preference-adherence evaluation for calendar scheduling.
+
+Grades a scheduled meeting against hard constraints and weighted soft
+preferences hand-translated from a task's natural-language preference document.
+"""
+
+from .helpers import (
+    DEFAULT_DAY_END,
+    DEFAULT_DAY_START,
+    DEFAULT_SLOT_STEP_MINUTES,
+    Predicate,
+    SoftPreference,
+    ends_by,
+    outside,
+    score_task,
+    starts_at_or_after,
+    to_hhmm,
+    to_minutes,
+    within,
+)
+from .types import PreferenceAdherenceResult
+
+__all__ = [
+    # Result type
+    "PreferenceAdherenceResult",
+    # Declarations
+    "Predicate",
+    "SoftPreference",
+    # Predicate constructors
+    "ends_by",
+    "outside",
+    "starts_at_or_after",
+    "within",
+    # Scorer
+    "score_task",
+    # Time helpers
+    "to_hhmm",
+    "to_minutes",
+    # Slot-grid defaults
+    "DEFAULT_DAY_END",
+    "DEFAULT_DAY_START",
+    "DEFAULT_SLOT_STEP_MINUTES",
+]

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -7,8 +7,9 @@ declarations: *hard constraints*, which every acceptable slot must satisfy, and
 what the assistant actually scheduled.
 
 Times are ``"HH:MM"`` strings externally and minutes-from-midnight internally.
-A :data:`Predicate` answers "is this candidate slot acceptable?" for a slot
-given as ``(start_minutes, end_minutes)``.
+A :class:`Predicate` answers "is this candidate slot acceptable?" for a slot
+given as ``(start_minutes, end_minutes)``, and declares the times at which its
+answer can change so that the best-slot search can be exact.
 
 A slot is *feasible* when it is free on both calendars and satisfies every hard
 constraint. Grading is then:
@@ -24,17 +25,35 @@ satisfy a set of wishes that no single slot can satisfy at once.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from ...types import LabeledMeeting, Meeting
 from .types import PreferenceAdherenceResult
 
-#: Accepts a candidate slot as ``(start_minutes, end_minutes)``.
-Predicate = Callable[[int, int], bool]
-
 DEFAULT_DAY_START = "08:00"
 DEFAULT_DAY_END = "19:00"
 DEFAULT_SLOT_STEP_MINUTES = 60
+
+
+@dataclass(frozen=True)
+class Predicate:
+    """A condition on a candidate slot, with the times its answer depends on.
+
+    Attributes:
+        test: Accepts a slot as ``(start_minutes, end_minutes)``.
+        breakpoints: Times, in minutes from midnight, at which ``test`` can
+            change its answer. Declaring them lets the scorer consider the
+            slots that sit exactly on a boundary instead of only those on a
+            fixed grid. A predicate that leaves this empty still works, but
+            the scorer may miss an optimum that falls between grid steps.
+    """
+
+    test: Callable[[int, int], bool]
+    breakpoints: tuple[int, ...] = field(default=())
+
+    def __call__(self, slot_start: int, slot_end: int) -> bool:
+        """Return whether the slot satisfies this condition."""
+        return self.test(slot_start, slot_end)
 
 
 @dataclass(frozen=True)
@@ -72,7 +91,10 @@ def to_hhmm(minutes: int) -> str:
 def within(start: str, end: str) -> Predicate:
     """Build a predicate requiring the slot to lie entirely inside ``[start, end]``."""
     lower, upper = to_minutes(start), to_minutes(end)
-    return lambda slot_start, slot_end: slot_start >= lower and slot_end <= upper
+    return Predicate(
+        test=lambda slot_start, slot_end: slot_start >= lower and slot_end <= upper,
+        breakpoints=(lower, upper),
+    )
 
 
 def outside(start: str, end: str) -> Predicate:
@@ -82,19 +104,28 @@ def outside(start: str, end: str) -> Predicate:
     ending exactly at *start* or beginning exactly at *end* is accepted.
     """
     lower, upper = to_minutes(start), to_minutes(end)
-    return lambda slot_start, slot_end: not (slot_start < upper and lower < slot_end)
+    return Predicate(
+        test=lambda slot_start, slot_end: not (slot_start < upper and lower < slot_end),
+        breakpoints=(lower, upper),
+    )
 
 
 def ends_by(time: str) -> Predicate:
     """Build a predicate requiring the slot to end at or before *time*."""
     limit = to_minutes(time)
-    return lambda _slot_start, slot_end: slot_end <= limit
+    return Predicate(
+        test=lambda _slot_start, slot_end: slot_end <= limit,
+        breakpoints=(limit,),
+    )
 
 
 def starts_at_or_after(time: str) -> Predicate:
     """Build a predicate requiring the slot to start at or after *time*."""
     limit = to_minutes(time)
-    return lambda slot_start, _slot_end: slot_start >= limit
+    return Predicate(
+        test=lambda slot_start, _slot_end: slot_start >= limit,
+        breakpoints=(limit,),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -112,12 +143,52 @@ def _is_free(start: int, end: int, busy: list[tuple[int, int]]) -> bool:
     return not any(start < busy_end and busy_start < end for busy_start, busy_end in busy)
 
 
-def _candidate_starts(day_start: str, day_end: str, duration: int, step: int) -> range:
-    """Return the start times to consider, spaced *step* minutes apart.
+def _candidate_starts(
+    day_start: str,
+    day_end: str,
+    duration: int,
+    step: int,
+    busy: list[tuple[int, int]],
+    constraints: list[Predicate],
+) -> list[int]:
+    """Return the start times to consider, from a regular sweep plus the boundaries.
 
-    Only slots that finish by *day_end* are included.
+    Two sources are combined:
+
+    * A sweep every *step* minutes. This contributes nothing to correctness;
+      it keeps the reported slot lists readable (08:00, 09:00, ...).
+    * The times at which something can actually change: the moment each
+      existing commitment ends, and, for every threshold a predicate declares,
+      the slot that starts on that threshold and the slot that ends on it.
+
+    The second source is what makes the search exact. Feasible start times form
+    a union of intervals, and within one interval the set of satisfied
+    preferences only changes at a declared threshold. Every such interval
+    therefore begins at the end of a commitment, at the day's start, or at a
+    threshold, so sampling those points cannot miss the best slot even when it
+    falls between two steps of the sweep.
+
+    Args:
+        day_start: First start time considered.
+        day_end: Latest time a slot may end.
+        duration: Meeting length in minutes.
+        step: Spacing of the regular sweep.
+        busy: Existing commitments from both calendars.
+        constraints: Every predicate whose thresholds matter, hard and soft.
+
+    Returns:
+        Ascending, de-duplicated start times within the bookable window.
     """
-    return range(to_minutes(day_start), to_minutes(day_end) - duration + 1, step)
+    earliest = to_minutes(day_start)
+    latest = to_minutes(day_end) - duration
+
+    times = set(range(earliest, latest + 1, step))
+    times.update(busy_end for _, busy_end in busy)
+    for constraint in constraints:
+        for boundary in constraint.breakpoints:
+            times.update((boundary, boundary - duration))
+
+    return sorted(time for time in times if earliest <= time <= latest)
 
 
 def _weight_of(
@@ -173,7 +244,9 @@ def score_task(
             assistant introduced itself are only visible via this flag.
         day_start: First candidate start time considered.
         day_end: Latest time a candidate slot may end.
-        step_minutes: Spacing between candidate start times.
+        step_minutes: Spacing of the regular slot sweep. Affects only how many
+            slots the explanation lists; the best-slot search stays exact
+            regardless because predicate boundaries are always considered.
 
     Returns:
         A PreferenceAdherenceResult with both scores and the supporting slot
@@ -195,7 +268,14 @@ def score_task(
 
     feasible = [
         start
-        for start in _candidate_starts(day_start, day_end, duration_minutes, step_minutes)
+        for start in _candidate_starts(
+            day_start,
+            day_end,
+            duration_minutes,
+            step_minutes,
+            busy=assistant_busy + requestor_busy,
+            constraints=hard_constraints + [p.predicate for p in soft_preferences],
+        )
         if is_acceptable(start, start + duration_minutes)
     ]
     feasible_hhmm = [to_hhmm(start) for start in feasible]
@@ -260,8 +340,9 @@ def score_task(
 
     chosen_weight, chosen_satisfied = _weight_of(chosen_start, chosen_end, soft_preferences)
 
-    # The chosen slot need not sit on the candidate grid, so it can out-score
-    # every slot considered. Doing better than the reference still scores 1.0.
+    # Every predicate boundary is a candidate, so a slot cannot normally beat
+    # the best considered. The clamp only guards a custom Predicate that
+    # declares no breakpoints, where the search degrades to the regular sweep.
     soft_score = 1.0 if best_weight == 0.0 else min(1.0, chosen_weight / best_weight)
 
     # Report misses against the earliest best slot, so the breakdown names one

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -1,0 +1,289 @@
+"""Shared building blocks for per-task preference verifiers.
+
+A task's natural-language preference document is hand-translated into two
+declarations: *hard constraints*, which every acceptable slot must satisfy, and
+*soft preferences*, which are weighted and used to rank the acceptable slots.
+:func:`score_task` combines those declarations with the two calendars to grade
+what the assistant actually scheduled.
+
+Times are ``"HH:MM"`` strings externally and minutes-from-midnight internally.
+A :data:`Predicate` answers "is this candidate slot acceptable?" for a slot
+given as ``(start_minutes, end_minutes)``.
+
+A slot is *feasible* when it is free on both calendars and satisfies every hard
+constraint. Grading is then:
+
+    hard = the scheduled slot is feasible, and has the right duration,
+           and introduced no conflict
+    soft = weight(chosen slot) / max weight over feasible slots
+
+Scoring soft preferences against the *best achievable* slot rather than against
+all preferences is what makes conflicting preferences well-defined: an
+assistant is asked to do as well as anything reachable could have done, not to
+satisfy a set of wishes that no single slot can satisfy at once.
+"""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+from ...types import LabeledMeeting, Meeting
+from .types import PreferenceAdherenceResult
+
+#: Accepts a candidate slot as ``(start_minutes, end_minutes)``.
+Predicate = Callable[[int, int], bool]
+
+DEFAULT_DAY_START = "08:00"
+DEFAULT_DAY_END = "19:00"
+DEFAULT_SLOT_STEP_MINUTES = 60
+
+
+@dataclass(frozen=True)
+class SoftPreference:
+    """A weighted, named soft preference over candidate slots.
+
+    Attributes:
+        name: Short identifier reported in the grading breakdown.
+        predicate: Returns True for slots that honour this preference.
+        weight: Relative importance when ranking slots. Preferences the task
+            author considers more important should carry a larger weight.
+    """
+
+    name: str
+    predicate: Predicate
+    weight: float = 1.0
+
+
+def to_minutes(hhmm: str) -> int:
+    """Convert ``"HH:MM"`` to minutes from midnight."""
+    hours, minutes = hhmm.split(":")
+    return int(hours) * 60 + int(minutes)
+
+
+def to_hhmm(minutes: int) -> str:
+    """Convert minutes from midnight to ``"HH:MM"``."""
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+# ---------------------------------------------------------------------------
+# Predicate constructors
+# ---------------------------------------------------------------------------
+
+
+def within(start: str, end: str) -> Predicate:
+    """Build a predicate requiring the slot to lie entirely inside ``[start, end]``."""
+    lower, upper = to_minutes(start), to_minutes(end)
+    return lambda slot_start, slot_end: slot_start >= lower and slot_end <= upper
+
+
+def outside(start: str, end: str) -> Predicate:
+    """Build a predicate requiring the slot not to overlap ``[start, end)``.
+
+    A slot that merely touches the boundary does not overlap, so a meeting
+    ending exactly at *start* or beginning exactly at *end* is accepted.
+    """
+    lower, upper = to_minutes(start), to_minutes(end)
+    return lambda slot_start, slot_end: not (slot_start < upper and lower < slot_end)
+
+
+def ends_by(time: str) -> Predicate:
+    """Build a predicate requiring the slot to end at or before *time*."""
+    limit = to_minutes(time)
+    return lambda _slot_start, slot_end: slot_end <= limit
+
+
+def starts_at_or_after(time: str) -> Predicate:
+    """Build a predicate requiring the slot to start at or after *time*."""
+    limit = to_minutes(time)
+    return lambda slot_start, _slot_end: slot_start >= limit
+
+
+# ---------------------------------------------------------------------------
+# Calendar helpers
+# ---------------------------------------------------------------------------
+
+
+def _busy_intervals(calendar: list[LabeledMeeting]) -> list[tuple[int, int]]:
+    """Return each meeting as a ``(start_minutes, end_minutes)`` pair."""
+    return [(to_minutes(m.start_time), to_minutes(m.end_time)) for m in calendar]
+
+
+def _is_free(start: int, end: int, busy: list[tuple[int, int]]) -> bool:
+    """Return whether ``[start, end)`` overlaps none of the busy intervals."""
+    return not any(start < busy_end and busy_start < end for busy_start, busy_end in busy)
+
+
+def _candidate_starts(day_start: str, day_end: str, duration: int, step: int) -> range:
+    """Return the start times to consider, spaced *step* minutes apart.
+
+    Only slots that finish by *day_end* are included.
+    """
+    return range(to_minutes(day_start), to_minutes(day_end) - duration + 1, step)
+
+
+def _weight_of(
+    start: int, end: int, soft_preferences: list[SoftPreference]
+) -> tuple[float, list[str]]:
+    """Return the total weight and names of the soft preferences a slot satisfies."""
+    satisfied = [p for p in soft_preferences if p.predicate(start, end)]
+    return sum(p.weight for p in satisfied), [p.name for p in satisfied]
+
+
+# ---------------------------------------------------------------------------
+# Scorer
+# ---------------------------------------------------------------------------
+
+
+def score_task(
+    scheduled_meeting: Meeting | None,
+    assistant_calendar: list[LabeledMeeting],
+    requestor_calendar: list[LabeledMeeting],
+    duration_minutes: int,
+    hard_constraints: list[Predicate] | None = None,
+    soft_preferences: list[SoftPreference] | None = None,
+    has_conflicts: bool = False,
+    day_start: str = DEFAULT_DAY_START,
+    day_end: str = DEFAULT_DAY_END,
+    step_minutes: int = DEFAULT_SLOT_STEP_MINUTES,
+) -> PreferenceAdherenceResult:
+    """Grade a scheduled meeting against a task's hard and soft preferences.
+
+    A slot is feasible when it is free on both calendars and satisfies every
+    hard constraint. Grading follows four cases:
+
+    1. **Nothing scheduled.** Declining is correct exactly when no slot was
+       feasible, so both scores are 1 in that case and 0 otherwise.
+    2. **Scheduled, but nothing was feasible.** The assistant should have
+       declined: both scores are 0.
+    3. **Scheduled on an unacceptable slot** — a conflict, the wrong duration,
+       a time that is busy, or a time a hard constraint forbids: both scores
+       are 0.
+    4. **Scheduled on an acceptable slot.** The soft score is the chosen
+       slot's weight over the best weight attainable on any feasible slot,
+       which is 1.0 when no soft preference is attainable at all.
+
+    Args:
+        scheduled_meeting: The meeting the assistant scheduled, or None.
+        assistant_calendar: The principal's calendar before the new meeting.
+        requestor_calendar: The requestor's calendar before the new meeting.
+        duration_minutes: Required meeting duration.
+        hard_constraints: Predicates every acceptable slot must satisfy.
+        soft_preferences: Weighted, named preferences used to rank slots.
+        has_conflicts: Whether task completion detected calendar conflicts.
+            The calendars passed here predate the new meeting, so conflicts the
+            assistant introduced itself are only visible via this flag.
+        day_start: First candidate start time considered.
+        day_end: Latest time a candidate slot may end.
+        step_minutes: Spacing between candidate start times.
+
+    Returns:
+        A PreferenceAdherenceResult with both scores and the supporting slot
+        analysis.
+    """
+    hard_constraints = hard_constraints or []
+    soft_preferences = soft_preferences or []
+
+    assistant_busy = _busy_intervals(assistant_calendar)
+    requestor_busy = _busy_intervals(requestor_calendar)
+
+    def is_acceptable(start: int, end: int) -> bool:
+        """Return whether a slot is free for both parties and allowed."""
+        return (
+            _is_free(start, end, assistant_busy)
+            and _is_free(start, end, requestor_busy)
+            and all(check(start, end) for check in hard_constraints)
+        )
+
+    feasible = [
+        start
+        for start in _candidate_starts(day_start, day_end, duration_minutes, step_minutes)
+        if is_acceptable(start, start + duration_minutes)
+    ]
+    feasible_hhmm = [to_hhmm(start) for start in feasible]
+
+    # Case 1: nothing was scheduled, which is correct only when nothing fits.
+    if scheduled_meeting is None:
+        declined_correctly = not feasible
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=declined_correctly,
+            soft_constraints_score=1.0 if declined_correctly else 0.0,
+            feasible_slots=feasible_hhmm,
+            explanation=(
+                "No slot satisfies the hard constraints; correctly declined to schedule."
+                if declined_correctly
+                else f"Nothing was scheduled even though {len(feasible)} slot(s) were "
+                f"available: {', '.join(feasible_hhmm)}."
+            ),
+        )
+
+    chosen_start = to_minutes(scheduled_meeting.start_time)
+    chosen_end = to_minutes(scheduled_meeting.end_time)
+    chosen_hhmm = to_hhmm(chosen_start)
+
+    # Case 2: a meeting was scheduled even though the task admits no valid slot.
+    if not feasible:
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=False,
+            soft_constraints_score=0.0,
+            chosen_slot=chosen_hhmm,
+            explanation=(
+                f"No slot satisfies the hard constraints, but a meeting was "
+                f"scheduled at {chosen_hhmm} instead of declining."
+            ),
+        )
+
+    # Case 3: the chosen slot itself breaks a hard requirement.
+    wrong_duration = chosen_end - chosen_start != duration_minutes
+    if has_conflicts or wrong_duration or not is_acceptable(chosen_start, chosen_end):
+        if has_conflicts:
+            reason = f"Scheduled at {chosen_hhmm}, but the final calendar has a conflict."
+        elif wrong_duration:
+            reason = (
+                f"Scheduled at {chosen_hhmm} for {chosen_end - chosen_start} minutes "
+                f"instead of the required {duration_minutes}."
+            )
+        else:
+            reason = f"Scheduled at {chosen_hhmm}, which violates a hard constraint."
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=False,
+            soft_constraints_score=0.0,
+            feasible_slots=feasible_hhmm,
+            chosen_slot=chosen_hhmm,
+            explanation=f"{reason} Feasible slots: {', '.join(feasible_hhmm)}.",
+        )
+
+    # Case 4: a valid slot; rank it against the best any feasible slot achieves.
+    weights = {
+        start: _weight_of(start, start + duration_minutes, soft_preferences) for start in feasible
+    }
+    best_weight = max(weight for weight, _ in weights.values())
+    best_slots = [to_hhmm(start) for start, (weight, _) in weights.items() if weight == best_weight]
+
+    chosen_weight, chosen_satisfied = _weight_of(chosen_start, chosen_end, soft_preferences)
+
+    # The chosen slot need not sit on the candidate grid, so it can out-score
+    # every slot considered. Doing better than the reference still scores 1.0.
+    soft_score = 1.0 if best_weight == 0.0 else min(1.0, chosen_weight / best_weight)
+
+    # Report misses against the earliest best slot, so the breakdown names one
+    # concrete alternative rather than a mix of mutually exclusive ones. A slot
+    # that already ties the best weight has missed nothing worth reporting.
+    missed: list[str] = []
+    if chosen_weight < best_weight:
+        reference_satisfied = next(
+            names for weight, names in weights.values() if weight == best_weight
+        )
+        missed = [name for name in reference_satisfied if name not in chosen_satisfied]
+
+    return PreferenceAdherenceResult(
+        hard_constraints_satisfied=True,
+        soft_constraints_score=soft_score,
+        feasible_slots=feasible_hhmm,
+        best_slots=best_slots,
+        chosen_slot=chosen_hhmm,
+        satisfied_soft_constraints=chosen_satisfied,
+        missed_soft_constraints=missed,
+        explanation=(
+            f"Scheduled at {chosen_hhmm} (soft weight {chosen_weight:g} of best "
+            f"{best_weight:g} at {', '.join(best_slots)}); soft score {soft_score:.3f}."
+        ),
+    )

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -1,31 +1,20 @@
 """Shared building blocks for per-task preference verifiers.
 
-A task's natural-language preference document is hand-translated into two
-declarations: *hard constraints*, which every acceptable slot must satisfy, and
-*soft preferences*, which are weighted and used to rank the acceptable slots.
-:func:`score_task` combines those declarations with the two calendars to grade
-what the assistant actually scheduled.
+A task's preference document is hand-translated into hard constraints, which
+every acceptable slot must satisfy, and weighted soft preferences, which rank
+the acceptable slots. :func:`score_task` grades what the assistant scheduled
+against both.
 
-Times are ``"HH:MM"`` strings externally and minutes-from-midnight internally.
-A :class:`Predicate` answers "is this candidate slot acceptable?" for a slot
-given as ``(start_minutes, end_minutes)``, and declares the times at which its
-answer can change so that the best-slot search can be exact.
+Times are ``"HH:MM"`` strings externally and minutes from midnight internally.
 
-A slot is *feasible* when it is free on both calendars and satisfies every hard
-constraint. Grading is then:
-
-    hard = the scheduled slot is feasible, and has the right duration,
-           and introduced no conflict
-    soft = weight(chosen slot) / max weight over feasible slots
-
-Scoring soft preferences against the *best achievable* slot rather than against
-all preferences is what makes conflicting preferences well-defined: an
-assistant is asked to do as well as anything reachable could have done, not to
-satisfy a set of wishes that no single slot can satisfy at once.
+Soft preferences are scored against the best achievable slot rather than
+against every stated preference, so a document whose preferences conflict stays
+winnable: the assistant is asked to do as well as anything reachable could have
+done, not to satisfy wishes no single slot can satisfy at once.
 """
 
 from collections.abc import Callable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 from ...types import LabeledMeeting, Meeting
 from .types import PreferenceAdherenceResult
@@ -37,35 +26,30 @@ DEFAULT_SLOT_STEP_MINUTES = 60
 
 @dataclass(frozen=True)
 class Predicate:
-    """A condition on a candidate slot, with the times its answer depends on.
+    """A condition on a slot given as ``(start_minutes, end_minutes)``.
 
-    Attributes:
-        test: Accepts a slot as ``(start_minutes, end_minutes)``.
-        breakpoints: Times, in minutes from midnight, at which ``test`` can
-            change its answer. Declaring them lets the scorer consider the
-            slots that sit exactly on a boundary instead of only those on a
-            fixed grid. A predicate that leaves this empty still works, but
-            the scorer may miss an optimum that falls between grid steps.
+    ``breakpoints`` lists the times at which ``test`` can change its answer.
+    The scorer considers the slots sitting on those boundaries, which is what
+    lets it find an optimum the regular sweep would step over.
     """
 
     test: Callable[[int, int], bool]
-    breakpoints: tuple[int, ...] = field(default=())
+    breakpoints: tuple[int, ...]
+
+    def __post_init__(self) -> None:
+        if not self.breakpoints:
+            raise ValueError(
+                "Predicate must declare the times at which its answer changes; "
+                "without them the scorer cannot reliably find the best slot."
+            )
 
     def __call__(self, slot_start: int, slot_end: int) -> bool:
-        """Return whether the slot satisfies this condition."""
         return self.test(slot_start, slot_end)
 
 
 @dataclass(frozen=True)
 class SoftPreference:
-    """A weighted, named soft preference over candidate slots.
-
-    Attributes:
-        name: Short identifier reported in the grading breakdown.
-        predicate: Returns True for slots that honour this preference.
-        weight: Relative importance when ranking slots. Preferences the task
-            author considers more important should carry a larger weight.
-    """
+    """A named, weighted preference used to rank candidate slots."""
 
     name: str
     predicate: Predicate
@@ -100,8 +84,8 @@ def within(start: str, end: str) -> Predicate:
 def outside(start: str, end: str) -> Predicate:
     """Build a predicate requiring the slot not to overlap ``[start, end)``.
 
-    A slot that merely touches the boundary does not overlap, so a meeting
-    ending exactly at *start* or beginning exactly at *end* is accepted.
+    Touching the boundary is not overlapping, so a meeting ending exactly at
+    *start* or beginning exactly at *end* is accepted.
     """
     lower, upper = to_minutes(start), to_minutes(end)
     return Predicate(
@@ -151,33 +135,14 @@ def _candidate_starts(
     busy: list[tuple[int, int]],
     constraints: list[Predicate],
 ) -> list[int]:
-    """Return the start times to consider, from a regular sweep plus the boundaries.
+    """Return the start times to consider, within the bookable window.
 
-    Two sources are combined:
-
-    * A sweep every *step* minutes. This contributes nothing to correctness;
-      it keeps the reported slot lists readable (08:00, 09:00, ...).
-    * The times at which something can actually change: the moment each
-      existing commitment ends, and, for every threshold a predicate declares,
-      the slot that starts on that threshold and the slot that ends on it.
-
-    The second source is what makes the search exact. Feasible start times form
-    a union of intervals, and within one interval the set of satisfied
-    preferences only changes at a declared threshold. Every such interval
-    therefore begins at the end of a commitment, at the day's start, or at a
-    threshold, so sampling those points cannot miss the best slot even when it
-    falls between two steps of the sweep.
-
-    Args:
-        day_start: First start time considered.
-        day_end: Latest time a slot may end.
-        duration: Meeting length in minutes.
-        step: Spacing of the regular sweep.
-        busy: Existing commitments from both calendars.
-        constraints: Every predicate whose thresholds matter, hard and soft.
-
-    Returns:
-        Ascending, de-duplicated start times within the bookable window.
+    The regular sweep every *step* minutes exists only to keep reported slot
+    lists readable. Exactness comes from also taking the times where something
+    can change: each commitment's end, and for every declared threshold both
+    the slot starting on it and the slot ending on it. Feasible starts form a
+    union of intervals whose satisfied preferences only change at those points,
+    so the best slot is always among them.
     """
     earliest = to_minutes(day_start)
     latest = to_minutes(day_end) - duration
@@ -218,19 +183,8 @@ def score_task(
 ) -> PreferenceAdherenceResult:
     """Grade a scheduled meeting against a task's hard and soft preferences.
 
-    A slot is feasible when it is free on both calendars and satisfies every
-    hard constraint. Grading follows four cases:
-
-    1. **Nothing scheduled.** Declining is correct exactly when no slot was
-       feasible, so both scores are 1 in that case and 0 otherwise.
-    2. **Scheduled, but nothing was feasible.** The assistant should have
-       declined: both scores are 0.
-    3. **Scheduled on an unacceptable slot** — a conflict, the wrong duration,
-       a time that is busy, or a time a hard constraint forbids: both scores
-       are 0.
-    4. **Scheduled on an acceptable slot.** The soft score is the chosen
-       slot's weight over the best weight attainable on any feasible slot,
-       which is 1.0 when no soft preference is attainable at all.
+    A slot is feasible when it falls inside the working day, is free on both
+    calendars, and satisfies every hard constraint.
 
     Args:
         scheduled_meeting: The meeting the assistant scheduled, or None.
@@ -240,17 +194,15 @@ def score_task(
         hard_constraints: Predicates every acceptable slot must satisfy.
         soft_preferences: Weighted, named preferences used to rank slots.
         has_conflicts: Whether task completion detected calendar conflicts.
-            The calendars passed here predate the new meeting, so conflicts the
+            The calendars here predate the new meeting, so conflicts the
             assistant introduced itself are only visible via this flag.
-        day_start: First candidate start time considered.
-        day_end: Latest time a candidate slot may end.
-        step_minutes: Spacing of the regular slot sweep. Affects only how many
-            slots the explanation lists; the best-slot search stays exact
-            regardless because predicate boundaries are always considered.
+        day_start: Earliest a meeting may begin.
+        day_end: Latest a meeting may end.
+        step_minutes: Spacing of the regular sweep. Affects how many slots the
+            explanation lists, not the score.
 
     Returns:
-        A PreferenceAdherenceResult with both scores and the supporting slot
-        analysis.
+        A PreferenceAdherenceResult with both scores and the slot analysis.
     """
     hard_constraints = hard_constraints or []
     soft_preferences = soft_preferences or []
@@ -259,7 +211,6 @@ def score_task(
     requestor_busy = _busy_intervals(requestor_calendar)
 
     def is_acceptable(start: int, end: int) -> bool:
-        """Return whether a slot is free for both parties and allowed."""
         return (
             _is_free(start, end, assistant_busy)
             and _is_free(start, end, requestor_busy)
@@ -280,7 +231,6 @@ def score_task(
     ]
     feasible_hhmm = [to_hhmm(start) for start in feasible]
 
-    # Case 1: nothing was scheduled, which is correct only when nothing fits.
     if scheduled_meeting is None:
         declined_correctly = not feasible
         return PreferenceAdherenceResult(
@@ -288,7 +238,7 @@ def score_task(
             soft_constraints_score=1.0 if declined_correctly else 0.0,
             feasible_slots=feasible_hhmm,
             explanation=(
-                "No slot satisfies the hard constraints; correctly declined to schedule."
+                "No slot is both available and allowed; correctly declined to schedule."
                 if declined_correctly
                 else f"Nothing was scheduled even though {len(feasible)} slot(s) were "
                 f"available: {', '.join(feasible_hhmm)}."
@@ -299,30 +249,33 @@ def score_task(
     chosen_end = to_minutes(scheduled_meeting.end_time)
     chosen_hhmm = to_hhmm(chosen_start)
 
-    # Case 2: a meeting was scheduled even though the task admits no valid slot.
     if not feasible:
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=False,
             soft_constraints_score=0.0,
             chosen_slot=chosen_hhmm,
             explanation=(
-                f"No slot satisfies the hard constraints, but a meeting was "
+                f"No slot is both available and allowed, but a meeting was "
                 f"scheduled at {chosen_hhmm} instead of declining."
             ),
         )
 
-    # Case 3: the chosen slot itself breaks a hard requirement.
-    wrong_duration = chosen_end - chosen_start != duration_minutes
-    if has_conflicts or wrong_duration or not is_acceptable(chosen_start, chosen_end):
+    def rejection_reason() -> str | None:
         if has_conflicts:
-            reason = f"Scheduled at {chosen_hhmm}, but the final calendar has a conflict."
-        elif wrong_duration:
-            reason = (
+            return f"Scheduled at {chosen_hhmm}, but the final calendar has a conflict."
+        if chosen_end - chosen_start != duration_minutes:
+            return (
                 f"Scheduled at {chosen_hhmm} for {chosen_end - chosen_start} minutes "
                 f"instead of the required {duration_minutes}."
             )
-        else:
-            reason = f"Scheduled at {chosen_hhmm}, which violates a hard constraint."
+        if chosen_start < to_minutes(day_start) or chosen_end > to_minutes(day_end):
+            return f"Scheduled at {chosen_hhmm}, outside the {day_start}-{day_end} day."
+        if not is_acceptable(chosen_start, chosen_end):
+            return f"Scheduled at {chosen_hhmm}, which is busy or violates a hard constraint."
+        return None
+
+    reason = rejection_reason()
+    if reason is not None:
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=False,
             soft_constraints_score=0.0,
@@ -331,7 +284,6 @@ def score_task(
             explanation=f"{reason} Feasible slots: {', '.join(feasible_hhmm)}.",
         )
 
-    # Case 4: a valid slot; rank it against the best any feasible slot achieves.
     weights = {
         start: _weight_of(start, start + duration_minutes, soft_preferences) for start in feasible
     }
@@ -340,19 +292,16 @@ def score_task(
 
     chosen_weight, chosen_satisfied = _weight_of(chosen_start, chosen_end, soft_preferences)
 
-    # Every predicate boundary is a candidate, so a slot cannot normally beat
-    # the best considered. The clamp only guards a custom Predicate that
-    # declares no breakpoints, where the search degrades to the regular sweep.
-    soft_score = 1.0 if best_weight == 0.0 else min(1.0, chosen_weight / best_weight)
+    # A feasible slot always ties one of the candidates, so this cannot exceed
+    # 1. If it ever does, the bounded result field raises rather than hiding it.
+    soft_score = 1.0 if best_weight == 0.0 else chosen_weight / best_weight
 
-    # Report misses against the earliest best slot, so the breakdown names one
-    # concrete alternative rather than a mix of mutually exclusive ones. A slot
-    # that already ties the best weight has missed nothing worth reporting.
+    # Name one concrete alternative rather than a mix of mutually exclusive
+    # ones. A slot tying the best weight forwent nothing.
     missed: list[str] = []
     if chosen_weight < best_weight:
-        reference_satisfied = next(
-            names for weight, names in weights.values() if weight == best_weight
-        )
+        earliest_best = next(start for start in feasible if weights[start][0] == best_weight)
+        _, reference_satisfied = weights[earliest_best]
         missed = [name for name in reference_satisfied if name not in chosen_satisfied]
 
     return PreferenceAdherenceResult(

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
@@ -8,26 +8,23 @@ class PreferenceAdherenceResult(BaseModel):
 
     hard_constraints_satisfied: bool = Field(
         description=(
-            "True iff the meeting landed on a slot that is free for both parties and "
-            "respects every hard constraint, or the task admits no such slot and the "
-            "assistant correctly declined to schedule."
+            "Whether the meeting landed on a feasible slot, or the task admits none "
+            "and the assistant correctly declined."
         )
     )
     soft_constraints_score: float = Field(
         ge=0.0,
         le=1.0,
         description=(
-            "Soft-preference adherence in [0, 1]: the weight of soft preferences met "
-            "by the chosen slot divided by the best weight achievable on any feasible "
-            "slot. 0.0 whenever a hard constraint is violated."
+            "Weight of the soft preferences the chosen slot met, over the best weight "
+            "achievable on any feasible slot. 0.0 if a hard constraint is violated."
         ),
     )
     feasible_slots: list[str] = Field(
         default_factory=list,
         description=(
-            "Representative start times (HH:MM) free for both parties that satisfy all "
-            "hard constraints. Includes every time where feasibility or soft-preference "
-            "adherence can change, so the best of these is the true best slot."
+            "Representative feasible start times (HH:MM), including every time at which "
+            "feasibility or soft-preference adherence can change."
         ),
     )
     best_slots: list[str] = Field(
@@ -45,8 +42,8 @@ class PreferenceAdherenceResult(BaseModel):
     missed_soft_constraints: list[str] = Field(
         default_factory=list,
         description=(
-            "Names of the soft preferences the earliest best slot honoured but the "
-            "chosen slot did not. Empty when the chosen slot ties the best weight."
+            "Soft preferences the earliest best slot honoured but the chosen slot did "
+            "not. Empty when the chosen slot ties the best weight."
         ),
     )
     explanation: str = Field(

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
@@ -1,0 +1,51 @@
+"""Result type for programmatic preference-adherence evaluation."""
+
+from pydantic import BaseModel, Field
+
+
+class PreferenceAdherenceResult(BaseModel):
+    """Outcome of grading a scheduled meeting against a task's preferences."""
+
+    hard_constraints_satisfied: bool = Field(
+        description=(
+            "True iff the meeting landed on a slot that is free for both parties and "
+            "respects every hard constraint, or the task admits no such slot and the "
+            "assistant correctly declined to schedule."
+        )
+    )
+    soft_constraints_score: float = Field(
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Soft-preference adherence in [0, 1]: the weight of soft preferences met "
+            "by the chosen slot divided by the best weight achievable on any feasible "
+            "slot. 0.0 whenever a hard constraint is violated."
+        ),
+    )
+    feasible_slots: list[str] = Field(
+        default_factory=list,
+        description="Start times (HH:MM) free for both parties that satisfy all hard constraints.",
+    )
+    best_slots: list[str] = Field(
+        default_factory=list,
+        description="Feasible start times achieving the maximum soft-preference weight.",
+    )
+    chosen_slot: str | None = Field(
+        default=None,
+        description="Start time (HH:MM) of the meeting the assistant scheduled.",
+    )
+    satisfied_soft_constraints: list[str] = Field(
+        default_factory=list,
+        description="Names of the soft preferences honoured by the chosen slot.",
+    )
+    missed_soft_constraints: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of the soft preferences the earliest best slot honoured but the "
+            "chosen slot did not. Empty when the chosen slot ties the best weight."
+        ),
+    )
+    explanation: str = Field(
+        default="",
+        description="Human-readable summary of the grading.",
+    )

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
@@ -24,7 +24,11 @@ class PreferenceAdherenceResult(BaseModel):
     )
     feasible_slots: list[str] = Field(
         default_factory=list,
-        description="Start times (HH:MM) free for both parties that satisfy all hard constraints.",
+        description=(
+            "Representative start times (HH:MM) free for both parties that satisfy all "
+            "hard constraints. Includes every time where feasibility or soft-preference "
+            "adherence can change, so the best of these is the true best slot."
+        ),
     )
     best_slots: list[str] = Field(
         default_factory=list,

--- a/packages/srbench/tests/test_calendar_preference_adherence.py
+++ b/packages/srbench/tests/test_calendar_preference_adherence.py
@@ -1,0 +1,313 @@
+"""Tests for the preference-adherence scoring engine.
+
+The engine is pure: it takes the two calendars plus a task's hard constraints
+and weighted soft preferences and grades whatever the assistant scheduled.
+These tests pin the scoring contract branch by branch.
+"""
+
+import pytest
+from srbench.benchmarks.calendar_scheduling.evaluation.preference_adherence import (
+    SoftPreference,
+    ends_by,
+    outside,
+    score_task,
+    starts_at_or_after,
+    to_hhmm,
+    to_minutes,
+    within,
+)
+from srbench.benchmarks.calendar_scheduling.types import LabeledMeeting, Meeting
+
+DURATION = 60
+
+
+def _busy(start_time: str, end_time: str) -> LabeledMeeting:
+    """Return a calendar entry occupying the given window."""
+    return LabeledMeeting(
+        uid=f"busy-{start_time}",
+        title="Existing commitment",
+        description="",
+        organizer="someone@example.com",
+        date="2024-06-15",
+        start_time=start_time,
+        end_time=end_time,
+        attendees=[],
+        is_movable=False,
+        is_secret=False,
+    )
+
+
+def _scheduled(start_time: str, end_time: str) -> Meeting:
+    """Return the meeting the assistant booked."""
+    return Meeting(
+        uid="new-001",
+        title="Project sync",
+        description="",
+        organizer="bob@example.com",
+        date="2024-06-15",
+        start_time=start_time,
+        end_time=end_time,
+        attendees=[],
+    )
+
+
+def _score(scheduled, assistant_calendar=None, requestor_calendar=None, **kwargs):
+    """Call score_task with empty calendars and a 60-minute meeting by default."""
+    return score_task(
+        scheduled_meeting=scheduled,
+        assistant_calendar=assistant_calendar or [],
+        requestor_calendar=requestor_calendar or [],
+        duration_minutes=DURATION,
+        **kwargs,
+    )
+
+
+class TestTimeHelpers:
+    """Tests for the HH:MM conversions."""
+
+    @pytest.mark.parametrize(
+        ("hhmm", "minutes"), [("00:00", 0), ("08:00", 480), ("13:30", 810), ("23:59", 1439)]
+    )
+    def test_round_trip(self, hhmm, minutes):
+        """Times convert to minutes and back without loss."""
+        assert to_minutes(hhmm) == minutes
+        assert to_hhmm(minutes) == hhmm
+
+
+class TestPredicates:
+    """Tests for the predicate constructors, including boundary behaviour."""
+
+    def test_within_accepts_contained_slots(self):
+        """A slot inside the window passes, including an exact fit."""
+        predicate = within("09:00", "12:00")
+
+        assert predicate(to_minutes("09:00"), to_minutes("10:00"))
+        assert predicate(to_minutes("09:00"), to_minutes("12:00"))
+
+    def test_within_rejects_slots_crossing_either_edge(self):
+        """A slot starting before or ending after the window fails."""
+        predicate = within("09:00", "12:00")
+
+        assert not predicate(to_minutes("08:30"), to_minutes("09:30"))
+        assert not predicate(to_minutes("11:30"), to_minutes("12:30"))
+
+    def test_outside_rejects_any_overlap(self):
+        """Partial and total overlaps with the excluded window fail."""
+        predicate = outside("12:00", "13:00")
+
+        assert not predicate(to_minutes("12:00"), to_minutes("13:00"))
+        assert not predicate(to_minutes("11:30"), to_minutes("12:30"))
+        assert not predicate(to_minutes("12:30"), to_minutes("13:30"))
+
+    def test_outside_accepts_touching_the_boundary(self):
+        """Ending exactly when the window opens, or starting when it closes, is fine."""
+        predicate = outside("12:00", "13:00")
+
+        assert predicate(to_minutes("11:00"), to_minutes("12:00"))
+        assert predicate(to_minutes("13:00"), to_minutes("14:00"))
+
+    def test_ends_by_is_inclusive(self):
+        """Ending exactly at the limit passes; ending later fails."""
+        predicate = ends_by("17:00")
+
+        assert predicate(to_minutes("16:00"), to_minutes("17:00"))
+        assert not predicate(to_minutes("16:30"), to_minutes("17:30"))
+
+    def test_starts_at_or_after_is_inclusive(self):
+        """Starting exactly at the limit passes; starting earlier fails."""
+        predicate = starts_at_or_after("13:00")
+
+        assert predicate(to_minutes("13:00"), to_minutes("14:00"))
+        assert not predicate(to_minutes("12:00"), to_minutes("13:00"))
+
+
+class TestNothingScheduled:
+    """Case 1: the assistant declined to schedule."""
+
+    def test_declining_is_correct_when_no_slot_is_feasible(self):
+        """Hard constraints that exclude the whole day make declining the right call."""
+        result = _score(None, hard_constraints=[within("22:00", "23:00")])
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+        assert result.feasible_slots == []
+
+    def test_declining_is_wrong_when_a_slot_was_available(self):
+        """Failing to schedule a satisfiable task scores zero on both axes."""
+        result = _score(None)
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "09:00" in result.feasible_slots
+
+    def test_busy_calendars_alone_can_make_a_task_infeasible(self):
+        """Feasibility accounts for both calendars, not just hard constraints."""
+        blocked = [_busy("08:00", "19:00")]
+
+        result = _score(None, assistant_calendar=blocked)
+
+        assert result.hard_constraints_satisfied
+        assert result.feasible_slots == []
+
+
+class TestScheduledButUnacceptable:
+    """Cases 2 and 3: something was scheduled that should not have been."""
+
+    def test_scheduling_when_nothing_is_feasible_scores_zero(self):
+        """The assistant should have declined instead."""
+        result = _score(_scheduled("09:00", "10:00"), hard_constraints=[within("22:00", "23:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert result.chosen_slot == "09:00"
+
+    def test_violating_a_hard_constraint_scores_zero(self):
+        """A slot outside the allowed window fails even though other slots were fine."""
+        result = _score(_scheduled("15:00", "16:00"), hard_constraints=[outside("12:00", "16:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "hard constraint" in result.explanation
+
+    def test_double_booking_scores_zero(self):
+        """Landing on a slot the requestor is busy for fails."""
+        result = _score(_scheduled("09:00", "10:00"), requestor_calendar=[_busy("09:00", "10:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+
+    def test_wrong_duration_scores_zero(self):
+        """A 30-minute booking does not satisfy a 60-minute request."""
+        result = _score(_scheduled("09:00", "09:30"))
+
+        assert not result.hard_constraints_satisfied
+        assert "30 minutes" in result.explanation
+
+    def test_reported_conflicts_score_zero(self):
+        """Conflicts the assistant introduced are only visible via has_conflicts."""
+        result = _score(_scheduled("09:00", "10:00"), has_conflicts=True)
+
+        assert not result.hard_constraints_satisfied
+        assert "conflict" in result.explanation
+
+
+class TestSoftPreferenceScoring:
+    """Case 4: the slot is acceptable, so soft preferences decide the score."""
+
+    def test_no_soft_preferences_scores_full_marks(self):
+        """With nothing to rank by, any acceptable slot is as good as any other."""
+        result = _score(_scheduled("09:00", "10:00"))
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+
+    def test_best_slot_scores_full_marks(self):
+        """Honouring every attainable preference scores 1.0."""
+        preferences = [SoftPreference("afternoon", starts_at_or_after("13:00"))]
+
+        result = _score(_scheduled("13:00", "14:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert result.satisfied_soft_constraints == ["afternoon"]
+        assert result.missed_soft_constraints == []
+
+    def test_suboptimal_slot_scores_the_attained_fraction(self):
+        """Meeting one of two attainable preferences scores 0.5."""
+        preferences = [
+            SoftPreference("afternoon", starts_at_or_after("13:00")),
+            SoftPreference("before_five", ends_by("17:00")),
+        ]
+
+        result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.5
+        assert result.satisfied_soft_constraints == ["afternoon"]
+        assert result.missed_soft_constraints == ["before_five"]
+
+    def test_weights_scale_the_fraction(self):
+        """A weight-3 preference is worth three times a weight-1 one."""
+        preferences = [
+            SoftPreference("afternoon", starts_at_or_after("13:00"), weight=3.0),
+            SoftPreference("before_five", ends_by("17:00"), weight=1.0),
+        ]
+
+        result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 0.75
+
+    def test_unattainable_preferences_do_not_penalise(self):
+        """A preference no feasible slot can meet is excluded from the reference."""
+        blocked = [_busy("08:00", "13:00")]
+        preferences = [SoftPreference("morning", ends_by("12:00"))]
+
+        result = _score(
+            _scheduled("13:00", "14:00"),
+            assistant_calendar=blocked,
+            soft_preferences=preferences,
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+
+    def test_conflicting_preferences_are_graded_against_the_best_slot(self):
+        """Two preferences no slot can satisfy together still allow a perfect score.
+
+        This is the case that makes grading against the best achievable slot
+        necessary: scoring against all preferences would cap every run at 0.5
+        and make the task look unsolvable.
+        """
+        preferences = [
+            SoftPreference("early", ends_by("10:00")),
+            SoftPreference("late", starts_at_or_after("16:00")),
+        ]
+
+        result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert sorted(result.best_slots) == ["08:00", "09:00", "16:00", "17:00", "18:00"]
+
+    def test_tying_the_best_weight_reports_no_misses(self):
+        """Picking a different but equally good slot is not reported as a miss.
+
+        The earliest best slot honours "early" while the chosen one honours
+        "late". Both are optimal, so nothing was forgone.
+        """
+        preferences = [
+            SoftPreference("early", ends_by("10:00")),
+            SoftPreference("late", starts_at_or_after("16:00")),
+        ]
+
+        result = _score(_scheduled("16:00", "17:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert result.satisfied_soft_constraints == ["late"]
+        assert result.missed_soft_constraints == []
+
+    def test_off_grid_slot_beating_the_reference_is_clamped(self):
+        """A slot between grid points may out-score the reference; 1.0 is the cap.
+
+        Candidate starts are on the hour, so no considered slot satisfies both
+        preferences. The 09:30 booking satisfies both and would score 2.0.
+        """
+        preferences = [
+            SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
+            SoftPreference("ends_by_ten_thirty", ends_by("10:30")),
+        ]
+
+        result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+        assert len(result.satisfied_soft_constraints) == 2
+
+    def test_feasible_slots_exclude_busy_and_forbidden_times(self):
+        """The reported slot list reflects both calendars and the hard constraints."""
+        result = _score(
+            _scheduled("13:00", "14:00"),
+            assistant_calendar=[_busy("08:00", "12:00")],
+            requestor_calendar=[_busy("15:00", "19:00")],
+            hard_constraints=[outside("12:00", "13:00")],
+        )
+
+        assert result.feasible_slots == ["13:00", "14:00"]

--- a/packages/srbench/tests/test_calendar_preference_adherence.py
+++ b/packages/srbench/tests/test_calendar_preference_adherence.py
@@ -7,6 +7,7 @@ These tests pin the scoring contract branch by branch.
 
 import pytest
 from srbench.benchmarks.calendar_scheduling.evaluation.preference_adherence import (
+    Predicate,
     SoftPreference,
     ends_by,
     outside,
@@ -119,6 +120,23 @@ class TestPredicates:
 
         assert predicate(to_minutes("13:00"), to_minutes("14:00"))
         assert not predicate(to_minutes("12:00"), to_minutes("13:00"))
+
+    @pytest.mark.parametrize(
+        ("predicate", "expected"),
+        [
+            (within("09:00", "12:00"), (540, 720)),
+            (outside("12:00", "13:00"), (720, 780)),
+            (ends_by("17:00"), (1020,)),
+            (starts_at_or_after("13:00"), (780,)),
+        ],
+    )
+    def test_constructors_declare_their_thresholds(self, predicate, expected):
+        """Each constructor reports the times at which its answer can change.
+
+        The scorer relies on these to consider boundary slots that a fixed
+        sweep would step over.
+        """
+        assert predicate.breakpoints == expected
 
 
 class TestNothingScheduled:
@@ -284,11 +302,13 @@ class TestSoftPreferenceScoring:
         assert result.satisfied_soft_constraints == ["late"]
         assert result.missed_soft_constraints == []
 
-    def test_off_grid_slot_beating_the_reference_is_clamped(self):
-        """A slot between grid points may out-score the reference; 1.0 is the cap.
+    def test_off_grid_optimum_is_found(self):
+        """The best slot is found even when it falls between two sweep steps.
 
-        Candidate starts are on the hour, so no considered slot satisfies both
-        preferences. The 09:30 booking satisfies both and would score 2.0.
+        The regular sweep only visits whole hours, and no whole hour satisfies
+        both preferences. Because each predicate declares its threshold, 09:30
+        is considered too, and it becomes the reference the booking is graded
+        against.
         """
         preferences = [
             SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
@@ -297,9 +317,70 @@ class TestSoftPreferenceScoring:
 
         result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
 
-        assert result.hard_constraints_satisfied
+        assert result.best_slots == ["09:30"]
         assert result.soft_constraints_score == 1.0
         assert len(result.satisfied_soft_constraints) == 2
+
+    def test_on_grid_booking_is_graded_against_the_off_grid_optimum(self):
+        """A whole-hour booking does not get full marks when 09:30 was better.
+
+        This is the case a fixed hourly grid gets wrong: it would rate 09:00
+        the joint best and award 1.0, hiding the strictly better slot.
+        """
+        preferences = [
+            SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
+            SoftPreference("ends_by_ten_thirty", ends_by("10:30")),
+        ]
+
+        result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.5
+        assert result.missed_soft_constraints == ["starts_after_nine_thirty"]
+
+    def test_slot_freed_by_a_commitment_ending_off_grid_is_considered(self):
+        """The moment an existing commitment ends is always a candidate."""
+        blocked = [_busy("08:00", "09:20")]
+        preferences = [SoftPreference("before_ten_twenty", ends_by("10:20"))]
+
+        result = _score(
+            _scheduled("10:30", "11:30"),
+            assistant_calendar=blocked,
+            soft_preferences=preferences,
+        )
+
+        assert "09:20" in result.feasible_slots
+        assert result.soft_constraints_score == 0.0
+
+    def test_half_hour_starts_are_considered_for_short_meetings(self):
+        """A 30-minute meeting can start on the half hour, so those slots count."""
+        result = score_task(
+            scheduled_meeting=_scheduled("08:30", "09:00"),
+            assistant_calendar=[],
+            requestor_calendar=[],
+            duration_minutes=30,
+            soft_preferences=[SoftPreference("after_eight_thirty", starts_at_or_after("08:30"))],
+        )
+
+        assert "08:30" in result.feasible_slots
+        assert result.hard_constraints_satisfied
+
+    def test_predicate_without_breakpoints_cannot_score_above_one(self):
+        """A custom predicate declaring nothing degrades safely rather than crashing.
+
+        With no thresholds to consider, the search falls back to the sweep and
+        can undercount the best weight, so the ratio is clamped. The result
+        field is bounded, so an unclamped ratio would fail validation.
+        """
+        at_nine_thirty = Predicate(test=lambda start, _end: start == to_minutes("09:30"))
+        preferences = [
+            SoftPreference("morning", ends_by("12:00")),
+            SoftPreference("exactly_nine_thirty", at_nine_thirty),
+        ]
+
+        result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
 
     def test_feasible_slots_exclude_busy_and_forbidden_times(self):
         """The reported slot list reflects both calendars and the hard constraints."""

--- a/packages/srbench/tests/test_calendar_preference_adherence.py
+++ b/packages/srbench/tests/test_calendar_preference_adherence.py
@@ -208,6 +208,14 @@ class TestScheduledButUnacceptable:
         assert not result.hard_constraints_satisfied
         assert "conflict" in result.explanation
 
+    def test_booking_outside_the_working_day_scores_zero(self):
+        """An evening slot is unacceptable even with both calendars empty."""
+        result = _score(_scheduled("20:00", "21:00"))
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "outside the 08:00-19:00 day" in result.explanation
+
 
 class TestSoftPreferenceScoring:
     """Case 4: the slot is acceptable, so soft preferences decide the score."""
@@ -365,22 +373,14 @@ class TestSoftPreferenceScoring:
         assert "08:30" in result.feasible_slots
         assert result.hard_constraints_satisfied
 
-    def test_predicate_without_breakpoints_cannot_score_above_one(self):
-        """A custom predicate declaring nothing degrades safely rather than crashing.
+    def test_predicate_must_declare_its_breakpoints(self):
+        """A predicate with no declared thresholds is rejected at construction.
 
-        With no thresholds to consider, the search falls back to the sweep and
-        can undercount the best weight, so the ratio is clamped. The result
-        field is bounded, so an unclamped ratio would fail validation.
+        Accepting one would silently degrade the search to the regular sweep,
+        so this fails where the mistake is made rather than at scoring time.
         """
-        at_nine_thirty = Predicate(test=lambda start, _end: start == to_minutes("09:30"))
-        preferences = [
-            SoftPreference("morning", ends_by("12:00")),
-            SoftPreference("exactly_nine_thirty", at_nine_thirty),
-        ]
-
-        result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
-
-        assert result.soft_constraints_score == 1.0
+        with pytest.raises(ValueError, match="must declare the times"):
+            Predicate(test=lambda start, _end: start == to_minutes("09:30"), breakpoints=())
 
     def test_feasible_slots_exclude_busy_and_forbidden_times(self):
         """The reported slot list reflects both calendars and the hard constraints."""


### PR DESCRIPTION
Stacked on #46. **PR 3 of 9** in the soft-preference port.

Pure, self-contained scoring. **Nothing imports it yet** — no existing behaviour can change. Wiring lands in PR 5.

## What this adds

`evaluation/preference_adherence/` with three pieces:

- **Predicate constructors** — `within`, `outside`, `ends_by`, `starts_at_or_after`.
- **`SoftPreference(name, predicate, weight)`** — a named, weighted preference used to rank slots.
- **`score_task(...)`** → `PreferenceAdherenceResult` with `hard_constraints_satisfied: bool` and `soft_constraints_score: float`.

A per-task verifier (PR 4/6) hand-translates a preference document into two lists:

```python
hard_constraints = [outside("12:00", "13:00")]         # "User never meets over lunch"
soft_preferences = [
    SoftPreference("afternoon", starts_at_or_after("13:00")),
    SoftPreference("before_five", ends_by("17:00"), weight=2.0),
]
```

## The scoring contract — the main thing to review

A slot is **feasible** iff it is inside the working day, free on both calendars, *and* satisfies every hard constraint.

| Situation | hard | soft |
|---|---|---|
| Nothing scheduled, nothing feasible | ✅ 1 | 1.0 |
| Nothing scheduled, a slot was feasible | ❌ 0 | 0.0 |
| Scheduled, but nothing was feasible | ❌ 0 | 0.0 |
| Scheduled on a conflicting / wrong-duration / out-of-hours / busy / forbidden slot | ❌ 0 | 0.0 |
| Scheduled on a feasible slot | ✅ 1 | `weight(chosen) / max weight over feasible` |

**Why divide by the best *attainable* weight rather than the total of all preferences?** Because preferences genuinely conflict. If a document says both "User prefers early mornings" and "User prefers to batch meetings late in the day", no single slot satisfies both; scoring against the total would cap every run at 0.5 and make the task look unsolvable. Grading against the best reachable slot asks the model to do as well as anything *could* have done.

<details>
<summary><b>Worked examples</b> — click to expand</summary>

All examples use a 60-minute meeting, an 08:00–19:00 day, and empty calendars unless stated.

### 1. No soft preferences: any feasible slot is perfect

```python
score_task(booked("09:00", "10:00"), [], [], 60)
# hard = True, soft = 1.0
```

Nothing to rank by, so there is no better slot to be graded against.

### 2. One of two preferences met

```python
prefs = [
    SoftPreference("afternoon", starts_at_or_after("13:00")),
    SoftPreference("before_five", ends_by("17:00")),
]
score_task(booked("17:00", "18:00"), [], [], 60, soft_preferences=prefs)
# hard = True, soft = 0.5
# satisfied = ["afternoon"], missed = ["before_five"]
```

13:00–17:00 slots satisfy both, so `best_weight = 2` and the 17:00 booking earns 1 of it.

### 3. Weights are respected

Same as above but `afternoon` carries `weight=3.0`:

```
best_weight = 4.0, chosen_weight = 3.0  →  soft = 0.75
```

### 4. Conflicting preferences stay winnable

```python
prefs = [
    SoftPreference("early", ends_by("10:00")),
    SoftPreference("late", starts_at_or_after("16:00")),
]
```

No slot satisfies both, so `best_weight = 1` and `best_slots = [08:00, 09:00, 16:00, 17:00, 18:00]`.

- Book **09:00** → `soft = 1.0`, missed `[]`
- Book **16:00** → `soft = 1.0`, missed `[]`  ← a different but equally optimal slot forgoes nothing
- Book **12:00** → `soft = 0.0`, missed `["early"]`

### 5. A hard constraint outranks every preference

```python
score_task(
    booked("15:00", "16:00"), [], [], 60,
    hard_constraints=[outside("12:00", "16:00")],
    soft_preferences=[SoftPreference("afternoon", starts_at_or_after("13:00"))],
)
# hard = False, soft = 0.0
# "Scheduled at 15:00, which is busy or violates a hard constraint."
```

### 6. Declining is only correct when nothing fits

```python
score_task(None, [], [], 60, hard_constraints=[within("22:00", "23:00")])
# hard = True, soft = 1.0   — nothing was feasible, so declining was right

score_task(None, [], [], 60)
# hard = False, soft = 0.0  — slots were available; the assistant should have booked one
```

This is the pair the impossible tier in PR 8 exercises.

### 7. The optimum can fall off the hour

```python
prefs = [
    SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
    SoftPreference("ends_by_ten_thirty", ends_by("10:30")),
]
```

No whole hour satisfies both; 09:30–10:30 does.

- Book **09:30** → `best_slots = ["09:30"]`, `soft = 1.0`
- Book **09:00** → `soft = 0.5`, missed `["starts_after_nine_thirty"]`

See below for why this works.

</details>

## Second commit: making the search exact

The first commit sampled candidates on a fixed hourly sweep, making `best_weight` a max over that sweep rather than over everything bookable. Using example 7 above:

| booking | prefs met | score (grid) | score (fixed) |
|---|---|---|---|
| 09:00–10:00 | 1 | **1.0** ❌ | 0.5 ✅ |
| 09:30–10:30 | 2 | 1.0 (clamped from 2.0) | 1.0 ✅ |

The grid rated a strictly worse booking as perfect. Separately, a 30-minute meeting could never be considered on the half hour, so `feasible_slots` was wrong too, not just the score.

**The fix.** `Predicate` becomes a small frozen dataclass carrying its `test` plus the `breakpoints` where its answer can change. Candidate starts are the union of the regular sweep (kept only so reported slot lists stay readable) with the times something can actually change: each commitment’s end, and for every declared threshold both the slot starting on it and the slot ending on it.

That is exact, not merely finer. Feasible starts form a union of intervals, and within one interval the satisfied-preference set only changes at a declared threshold — so every interval begins at a commitment end, the day’s start, or a threshold.

**Constructor signatures are unchanged**, so verifier code in PRs 4 and 6 is unaffected.

## Third commit: fail loudly, and less prose

- **`breakpoints` is now required.** An empty tuple raises at construction. Accepting one silently degraded the search back to the sweep — the very bug above — so it now fails where the mistake is made.
- **Out-of-hours bookings are rejected explicitly.** A 20:00 booking previously passed the acceptability check (the calendars say nothing about the evening) and could out-score everything in the window. It now gets its own message instead of the misleading "violates a hard constraint".
- **The `min(1.0, ...)` clamp is gone.** With both of the above, a feasible slot always ties one of the candidates. If that ever breaks, the bounded result field raises rather than quietly reporting a score above 1.
- **Documentation cut back** to what the code cannot say itself (−54 lines, almost all prose): the four-case list duplicated the branch structure, `_candidate_starts` carried a proof sketch, and several docstrings restated their own field names. Two comments remain, both explaining *why*.

`has_conflicts` is passed in rather than derived because the calendars given here predate the new meeting, so a conflict the assistant introduced itself is invisible to this function.

## Testing

36 tests: predicate boundary behaviour (touching edges, inclusive limits), declared thresholds, breakpoint validation, every branch of the contract, weighted fractions, unattainable and conflicting preferences, tie handling, out-of-hours rejection, and four exactness cases — off-grid optimum found, on-grid booking graded against it, slot freed by an off-grid commitment end, and half-hour starts for short meetings.

Suite matches the `origin/main` baseline (8 failed / 1 skipped / 3 errors, all pre-existing); passing 239 → 275. `poe check` clean.