### PR TITLE
feat(calendar): add the preference adherence scoring contract

### DIFF
--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/__init__.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/__init__.py
@@ -1,8 +1,7 @@
 """Programmatic preference-adherence evaluation for calendar scheduling.
 
-Provides the vocabulary a task's natural-language preference document is
-hand-translated into: hard constraints every acceptable slot must satisfy, and
-weighted soft preferences that rank the acceptable slots.
+Grades a scheduled meeting against hard constraints and weighted soft
+preferences hand-translated from a task's natural-language preference document.
 """
 
 from .helpers import (
@@ -10,14 +9,18 @@ from .helpers import (
     SoftPreference,
     ends_by,
     outside,
+    score_task,
     starts_at_or_after,
     starts_within,
     to_hhmm,
     to_minutes,
     within,
 )
+from .types import PreferenceAdherenceResult
 
 __all__ = [
+    # Result type
+    "PreferenceAdherenceResult",
     # Declarations
     "Predicate",
     "SoftPreference",
@@ -27,6 +30,8 @@ __all__ = [
     "starts_at_or_after",
     "starts_within",
     "within",
+    # Scorer
+    "score_task",
     # Time helpers
     "to_hhmm",
     "to_minutes",

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -148,14 +148,24 @@ def score_task(
 ) -> PreferenceAdherenceResult:
     """Grade a scheduled meeting against a task's hard and soft preferences.
 
-    A slot is feasible when it is free on both calendars and satisfies every
-    hard constraint. Nothing else narrows the day: the preference document is
-    the only authority on when the principal is bookable.
+    A slot is *bookable* when it is free on the principal's calendar and
+    satisfies every hard constraint. Nothing else narrows the day: the
+    preference document is the only authority on when the principal is
+    bookable. The requestor's calendar in particular does not, because the
+    assistant acts for its principal; a requestor who takes a slot it is
+    already busy for has only double-booked itself.
+
+    A bookable slot is *feasible* when the requestor is free for it too. The
+    best feasible slot sets the bar the soft score is measured against, which
+    leaves the assistant unpenalized whichever way it goes: taking the best
+    slot that suits everyone earns full marks, and so does a bookable slot the
+    requestor happened to be busy for, whose ratio is clipped at 1.
 
     Args:
         scheduled_meeting: The meeting the assistant scheduled, or None.
         assistant_calendar: The principal's calendar before the new meeting.
         requestor_calendar: The requestor's calendar before the new meeting.
+            Used only to set the bar, never to rule a slot out.
         duration_minutes: Required meeting duration.
         hard_constraints: Predicates every acceptable slot must satisfy.
         soft_preferences: Weighted, named preferences used to rank slots.
@@ -170,8 +180,13 @@ def score_task(
     hard_constraints = hard_constraints or []
     soft_preferences = soft_preferences or []
 
-    busy = _busy_intervals(assistant_calendar) + _busy_intervals(requestor_calendar)
-    feasible = _feasible_starts(duration_minutes, busy, hard_constraints)
+    assistant_busy = _busy_intervals(assistant_calendar)
+    bookable = _feasible_starts(duration_minutes, assistant_busy, hard_constraints)
+    feasible = _feasible_starts(
+        duration_minutes,
+        assistant_busy + _busy_intervals(requestor_calendar),
+        hard_constraints,
+    )
     feasible_windows = _as_windows(feasible)
 
     if scheduled_meeting is None:
@@ -192,7 +207,7 @@ def score_task(
     chosen_end = to_minutes(scheduled_meeting.end_time)
     chosen_hhmm = to_hhmm(chosen_start)
 
-    if not feasible:
+    if not bookable:
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=False,
             soft_preferences_score=0.0,
@@ -211,7 +226,7 @@ def score_task(
             f"Scheduled at {chosen_hhmm} for {chosen_end - chosen_start} minutes "
             f"instead of the required {duration_minutes}."
         )
-    elif chosen_start not in feasible:
+    elif chosen_start not in bookable:
         reason = f"Scheduled at {chosen_hhmm}, which is busy or against a hard constraint."
 
     if reason is not None:
@@ -220,7 +235,25 @@ def score_task(
             soft_preferences_score=0.0,
             feasible_windows=feasible_windows,
             chosen_slot=chosen_hhmm,
-            explanation=f"{reason} Feasible start times: {', '.join(feasible_windows)}.",
+            explanation=f"{reason} Bookable start times: {', '.join(_as_windows(bookable))}.",
+        )
+
+    chosen_weight, chosen_satisfied = _weight_of(
+        chosen_start, chosen_start + duration_minutes, soft_preferences
+    )
+
+    # Nothing suited both calendars, so there is no bar to fall short of: the
+    # assistant found the principal a slot no cooperative choice could beat.
+    if not feasible:
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=True,
+            soft_preferences_score=1.0,
+            chosen_slot=chosen_hhmm,
+            satisfied_soft_preferences=chosen_satisfied,
+            explanation=(
+                f"Scheduled at {chosen_hhmm}; no slot was free for the requestor too, "
+                f"so booking over their calendar is the best available outcome."
+            ),
         )
 
     weights = {
@@ -229,8 +262,9 @@ def score_task(
     best_weight = max(weight for weight, _ in weights.values())
     best_windows = _as_windows([start for start in feasible if weights[start][0] == best_weight])
 
-    chosen_weight, chosen_satisfied = weights[chosen_start]
-    soft_score = 1.0 if best_weight == 0.0 else chosen_weight / best_weight
+    # Clipped because the bar is the best slot free for both. Beating it means
+    # booking over the requestor, which is allowed but is not extra credit.
+    soft_score = 1.0 if best_weight <= 0.0 else min(1.0, chosen_weight / best_weight)
 
     # Name one concrete alternative rather than a mix of mutually exclusive
     # ones. A slot tying the best weight forwent nothing.
@@ -251,5 +285,10 @@ def score_task(
         explanation=(
             f"Scheduled at {chosen_hhmm} (soft weight {chosen_weight:g} of best "
             f"{best_weight:g} at {', '.join(best_windows)}); soft score {soft_score:.3f}."
+            + (
+                " The requestor was busy then, so this beat everything free for both."
+                if chosen_start not in feasible
+                else ""
+            )
         ),
     )

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -2,16 +2,22 @@
 
 A task's preference document is hand-translated into hard constraints, which
 every acceptable slot must satisfy, and weighted soft preferences, which rank
-the acceptable slots. This module provides the vocabulary for writing both, and
-the search that finds the slots they are evaluated over.
+the acceptable slots. :func:`score_task` grades what the assistant scheduled
+against both.
 
 Times are ``"HH:MM"`` strings externally and minutes from midnight internally.
+
+Soft preferences are scored against the best achievable slot rather than
+against every stated preference, so a document whose preferences conflict stays
+winnable: the assistant is asked to do as well as anything reachable could have
+done, not to satisfy wishes no single slot can satisfy at once.
 """
 
 from collections.abc import Callable
 from dataclasses import dataclass
 
-from ...types import LabeledMeeting
+from ...types import LabeledMeeting, Meeting
+from .types import PreferenceAdherenceResult
 
 MINUTES_PER_DAY = 24 * 60
 
@@ -129,3 +135,121 @@ def _weight_of(
     """Return the total weight and names of the soft preferences a slot satisfies."""
     satisfied = [p for p in soft_preferences if p.predicate(start, end)]
     return sum(p.weight for p in satisfied), [p.name for p in satisfied]
+
+
+def score_task(
+    scheduled_meeting: Meeting | None,
+    assistant_calendar: list[LabeledMeeting],
+    requestor_calendar: list[LabeledMeeting],
+    duration_minutes: int,
+    hard_constraints: list[Predicate] | None = None,
+    soft_preferences: list[SoftPreference] | None = None,
+    has_conflicts: bool = False,
+) -> PreferenceAdherenceResult:
+    """Grade a scheduled meeting against a task's hard and soft preferences.
+
+    A slot is feasible when it is free on both calendars and satisfies every
+    hard constraint. Nothing else narrows the day: the preference document is
+    the only authority on when the principal is bookable.
+
+    Args:
+        scheduled_meeting: The meeting the assistant scheduled, or None.
+        assistant_calendar: The principal's calendar before the new meeting.
+        requestor_calendar: The requestor's calendar before the new meeting.
+        duration_minutes: Required meeting duration.
+        hard_constraints: Predicates every acceptable slot must satisfy.
+        soft_preferences: Weighted, named preferences used to rank slots.
+        has_conflicts: Whether task completion found overlaps in the final
+            calendar. The calendars here are the pre-episode ones, so an
+            overlap between two meetings created during the episode is
+            invisible to this function and has to be passed in.
+
+    Returns:
+        A PreferenceAdherenceResult with both scores and the slot analysis.
+    """
+    hard_constraints = hard_constraints or []
+    soft_preferences = soft_preferences or []
+
+    busy = _busy_intervals(assistant_calendar) + _busy_intervals(requestor_calendar)
+    feasible = _feasible_starts(duration_minutes, busy, hard_constraints)
+    feasible_windows = _as_windows(feasible)
+
+    if scheduled_meeting is None:
+        declined_correctly = not feasible
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=declined_correctly,
+            soft_constraints_score=1.0 if declined_correctly else 0.0,
+            feasible_windows=feasible_windows,
+            explanation=(
+                "No slot is both available and allowed; correctly declined to schedule."
+                if declined_correctly
+                else "Nothing was scheduled even though the meeting would have fit at "
+                f"{', '.join(feasible_windows)}."
+            ),
+        )
+
+    chosen_start = to_minutes(scheduled_meeting.start_time)
+    chosen_end = to_minutes(scheduled_meeting.end_time)
+    chosen_hhmm = to_hhmm(chosen_start)
+
+    if not feasible:
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=False,
+            soft_constraints_score=0.0,
+            chosen_slot=chosen_hhmm,
+            explanation=(
+                f"No slot is both available and allowed, but a meeting was "
+                f"scheduled at {chosen_hhmm} instead of declining."
+            ),
+        )
+
+    reason: str | None = None
+    if has_conflicts:
+        reason = f"Scheduled at {chosen_hhmm}, but the final calendar has a conflict."
+    elif chosen_end - chosen_start != duration_minutes:
+        reason = (
+            f"Scheduled at {chosen_hhmm} for {chosen_end - chosen_start} minutes "
+            f"instead of the required {duration_minutes}."
+        )
+    elif chosen_start not in feasible:
+        reason = f"Scheduled at {chosen_hhmm}, which is busy or against a hard constraint."
+
+    if reason is not None:
+        return PreferenceAdherenceResult(
+            hard_constraints_satisfied=False,
+            soft_constraints_score=0.0,
+            feasible_windows=feasible_windows,
+            chosen_slot=chosen_hhmm,
+            explanation=f"{reason} Feasible start times: {', '.join(feasible_windows)}.",
+        )
+
+    weights = {
+        start: _weight_of(start, start + duration_minutes, soft_preferences) for start in feasible
+    }
+    best_weight = max(weight for weight, _ in weights.values())
+    best_windows = _as_windows([start for start in feasible if weights[start][0] == best_weight])
+
+    chosen_weight, chosen_satisfied = weights[chosen_start]
+    soft_score = 1.0 if best_weight == 0.0 else chosen_weight / best_weight
+
+    # Name one concrete alternative rather than a mix of mutually exclusive
+    # ones. A slot tying the best weight forwent nothing.
+    missed: list[str] = []
+    if chosen_weight < best_weight:
+        earliest_best = next(start for start in feasible if weights[start][0] == best_weight)
+        _, reference_satisfied = weights[earliest_best]
+        missed = [name for name in reference_satisfied if name not in chosen_satisfied]
+
+    return PreferenceAdherenceResult(
+        hard_constraints_satisfied=True,
+        soft_constraints_score=soft_score,
+        feasible_windows=feasible_windows,
+        best_windows=best_windows,
+        chosen_slot=chosen_hhmm,
+        satisfied_soft_constraints=chosen_satisfied,
+        missed_soft_constraints=missed,
+        explanation=(
+            f"Scheduled at {chosen_hhmm} (soft weight {chosen_weight:g} of best "
+            f"{best_weight:g} at {', '.join(best_windows)}); soft score {soft_score:.3f}."
+        ),
+    )

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/helpers.py
@@ -178,7 +178,7 @@ def score_task(
         declined_correctly = not feasible
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=declined_correctly,
-            soft_constraints_score=1.0 if declined_correctly else 0.0,
+            soft_preferences_score=1.0 if declined_correctly else 0.0,
             feasible_windows=feasible_windows,
             explanation=(
                 "No slot is both available and allowed; correctly declined to schedule."
@@ -195,7 +195,7 @@ def score_task(
     if not feasible:
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=False,
-            soft_constraints_score=0.0,
+            soft_preferences_score=0.0,
             chosen_slot=chosen_hhmm,
             explanation=(
                 f"No slot is both available and allowed, but a meeting was "
@@ -217,7 +217,7 @@ def score_task(
     if reason is not None:
         return PreferenceAdherenceResult(
             hard_constraints_satisfied=False,
-            soft_constraints_score=0.0,
+            soft_preferences_score=0.0,
             feasible_windows=feasible_windows,
             chosen_slot=chosen_hhmm,
             explanation=f"{reason} Feasible start times: {', '.join(feasible_windows)}.",
@@ -242,12 +242,12 @@ def score_task(
 
     return PreferenceAdherenceResult(
         hard_constraints_satisfied=True,
-        soft_constraints_score=soft_score,
+        soft_preferences_score=soft_score,
         feasible_windows=feasible_windows,
         best_windows=best_windows,
         chosen_slot=chosen_hhmm,
-        satisfied_soft_constraints=chosen_satisfied,
-        missed_soft_constraints=missed,
+        satisfied_soft_preferences=chosen_satisfied,
+        missed_soft_preferences=missed,
         explanation=(
             f"Scheduled at {chosen_hhmm} (soft weight {chosen_weight:g} of best "
             f"{best_weight:g} at {', '.join(best_windows)}); soft score {soft_score:.3f}."

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
@@ -12,7 +12,7 @@ class PreferenceAdherenceResult(BaseModel):
             "and the assistant correctly declined."
         )
     )
-    soft_constraints_score: float = Field(
+    soft_preferences_score: float = Field(
         ge=0.0,
         le=1.0,
         description=(
@@ -35,11 +35,11 @@ class PreferenceAdherenceResult(BaseModel):
         default=None,
         description="Start time (HH:MM) of the meeting the assistant scheduled.",
     )
-    satisfied_soft_constraints: list[str] = Field(
+    satisfied_soft_preferences: list[str] = Field(
         default_factory=list,
         description="Names of the soft preferences honored by the chosen slot.",
     )
-    missed_soft_constraints: list[str] = Field(
+    missed_soft_preferences: list[str] = Field(
         default_factory=list,
         description=(
             "Soft preferences the earliest best slot honored but the chosen slot did "

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/evaluation/preference_adherence/types.py
@@ -1,0 +1,52 @@
+"""Result type for programmatic preference-adherence evaluation."""
+
+from pydantic import BaseModel, Field
+
+
+class PreferenceAdherenceResult(BaseModel):
+    """Outcome of grading a scheduled meeting against a task's preferences."""
+
+    hard_constraints_satisfied: bool = Field(
+        description=(
+            "Whether the meeting landed on a feasible slot, or the task admits none "
+            "and the assistant correctly declined."
+        )
+    )
+    soft_constraints_score: float = Field(
+        ge=0.0,
+        le=1.0,
+        description=(
+            "Weight of the soft preferences the chosen slot met, over the best weight "
+            "achievable on any feasible slot. 0.0 if a hard constraint is violated."
+        ),
+    )
+    feasible_windows: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Ranges of start times the meeting could have taken, as inclusive "
+            "HH:MM-HH:MM windows, or a bare HH:MM for a one-minute range."
+        ),
+    )
+    best_windows: list[str] = Field(
+        default_factory=list,
+        description="Feasible start times achieving the maximum soft-preference weight.",
+    )
+    chosen_slot: str | None = Field(
+        default=None,
+        description="Start time (HH:MM) of the meeting the assistant scheduled.",
+    )
+    satisfied_soft_constraints: list[str] = Field(
+        default_factory=list,
+        description="Names of the soft preferences honored by the chosen slot.",
+    )
+    missed_soft_constraints: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Soft preferences the earliest best slot honored but the chosen slot did "
+            "not. Empty when the chosen slot ties the best weight."
+        ),
+    )
+    explanation: str = Field(
+        default="",
+        description="Human-readable summary of the grading.",
+    )

--- a/packages/srbench/tests/test_calendar_preference_scoring.py
+++ b/packages/srbench/tests/test_calendar_preference_scoring.py
@@ -1,0 +1,334 @@
+"""Tests for the preference-adherence scoring contract.
+
+The scorer is pure: it takes the two calendars plus a task's hard constraints
+and weighted soft preferences and grades whatever the assistant scheduled.
+These tests pin the contract branch by branch. Bookable hours are not built
+in, so the tests declare a working day as a hard constraint the way a real
+preference document does.
+"""
+
+from srbench.benchmarks.calendar_scheduling.evaluation.preference_adherence import (
+    SoftPreference,
+    ends_by,
+    outside,
+    score_task,
+    starts_at_or_after,
+    within,
+)
+from srbench.benchmarks.calendar_scheduling.types import LabeledMeeting, Meeting
+
+DURATION = 60
+WORKING_DAY = within("08:00", "19:00")
+
+
+def _busy(start_time: str, end_time: str) -> LabeledMeeting:
+    """Return a calendar entry occupying the given window."""
+    return LabeledMeeting(
+        uid=f"busy-{start_time}",
+        title="Existing commitment",
+        description="",
+        organizer="someone@example.com",
+        date="2024-06-15",
+        start_time=start_time,
+        end_time=end_time,
+        attendees=[],
+        is_movable=False,
+        is_secret=False,
+    )
+
+
+def _scheduled(start_time: str, end_time: str) -> Meeting:
+    """Return the meeting the assistant booked."""
+    return Meeting(
+        uid="new-001",
+        title="Project sync",
+        description="",
+        organizer="bob@example.com",
+        date="2024-06-15",
+        start_time=start_time,
+        end_time=end_time,
+        attendees=[],
+    )
+
+
+def _score(
+    scheduled, assistant_calendar=None, requestor_calendar=None, hard_constraints=None, **kwargs
+):
+    """Call score_task over an 08:00-19:00 working day and empty calendars."""
+    return score_task(
+        scheduled_meeting=scheduled,
+        assistant_calendar=assistant_calendar or [],
+        requestor_calendar=requestor_calendar or [],
+        duration_minutes=DURATION,
+        hard_constraints=[WORKING_DAY, *(hard_constraints or [])],
+        **kwargs,
+    )
+
+
+class TestNothingScheduled:
+    """Tests for the case where the assistant declined to schedule."""
+
+    def test_declining_is_correct_when_no_slot_is_feasible(self):
+        """Hard constraints that cannot both hold make declining the right call."""
+        result = _score(None, hard_constraints=[ends_by("09:00"), starts_at_or_after("15:00")])
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+        assert result.feasible_windows == []
+
+    def test_declining_is_wrong_when_a_slot_was_available(self):
+        """Failing to schedule a satisfiable task scores zero on both axes."""
+        result = _score(None)
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert result.feasible_windows == ["08:00-18:00"]
+
+    def test_busy_calendars_alone_can_make_a_task_infeasible(self):
+        """Feasibility accounts for both calendars, not just hard constraints."""
+        blocked = [_busy("08:00", "19:00")]
+
+        result = _score(None, assistant_calendar=blocked)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+        assert result.feasible_windows == []
+
+
+class TestScheduledButUnacceptable:
+    """Tests for booking something that should not have been booked."""
+
+    def test_scheduling_when_nothing_is_feasible_scores_zero(self):
+        """The assistant should have declined instead."""
+        result = _score(_scheduled("09:00", "10:00"), hard_constraints=[within("22:00", "23:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert result.chosen_slot == "09:00"
+
+    def test_violating_a_hard_constraint_scores_zero(self):
+        """A slot outside the allowed window fails even though other slots were fine."""
+        result = _score(_scheduled("15:00", "16:00"), hard_constraints=[outside("12:00", "16:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "against a hard constraint" in result.explanation
+
+    def test_double_booking_scores_zero(self):
+        """Landing on a slot the requestor is busy for fails."""
+        result = _score(_scheduled("09:00", "10:00"), requestor_calendar=[_busy("09:00", "10:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+
+    def test_wrong_duration_scores_zero(self):
+        """A 30-minute booking does not satisfy a 60-minute request."""
+        result = _score(_scheduled("09:00", "09:30"))
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "30 minutes" in result.explanation
+
+    def test_reported_conflicts_score_zero(self):
+        """Conflicts the assistant introduced are only visible via has_conflicts."""
+        result = _score(_scheduled("09:00", "10:00"), has_conflicts=True)
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "conflict" in result.explanation
+
+    def test_booking_outside_the_working_day_scores_zero(self):
+        """An evening slot is unacceptable even with both calendars empty."""
+        result = _score(_scheduled("20:00", "21:00"))
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.0
+        assert "against a hard constraint" in result.explanation
+
+
+class TestSoftPreferenceScoring:
+    """Tests for ranking an acceptable slot against the soft preferences."""
+
+    def test_no_soft_preferences_scores_full_marks(self):
+        """With nothing to rank by, any acceptable slot is as good as any other."""
+        result = _score(_scheduled("09:00", "10:00"))
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+
+    def test_best_slot_scores_full_marks(self):
+        """Honoring every attainable preference scores 1.0."""
+        preferences = [SoftPreference("afternoon", starts_at_or_after("13:00"))]
+
+        result = _score(_scheduled("13:00", "14:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert result.satisfied_soft_constraints == ["afternoon"]
+        assert result.missed_soft_constraints == []
+
+    def test_suboptimal_slot_scores_the_attained_fraction(self):
+        """Meeting one of two attainable preferences scores 0.5."""
+        preferences = [
+            SoftPreference("afternoon", starts_at_or_after("13:00")),
+            SoftPreference("before_five", ends_by("17:00")),
+        ]
+
+        result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.5
+        assert result.satisfied_soft_constraints == ["afternoon"]
+        assert result.missed_soft_constraints == ["before_five"]
+
+    def test_weights_scale_the_fraction(self):
+        """A weight-3 preference is worth three times a weight-1 one."""
+        preferences = [
+            SoftPreference("afternoon", starts_at_or_after("13:00"), weight=3.0),
+            SoftPreference("before_five", ends_by("17:00"), weight=1.0),
+        ]
+
+        result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 0.75
+
+    def test_unattainable_preferences_do_not_penalise(self):
+        """A preference no feasible slot can meet is excluded from the reference."""
+        blocked = [_busy("08:00", "13:00")]
+        preferences = [SoftPreference("morning", ends_by("12:00"))]
+
+        result = _score(
+            _scheduled("13:00", "14:00"),
+            assistant_calendar=blocked,
+            soft_preferences=preferences,
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+
+    def test_conflicting_preferences_are_graded_against_the_best_slot(self):
+        """Two preferences no slot can satisfy together still allow a perfect score.
+
+        This is the case that makes grading against the best achievable slot
+        necessary: scoring against all preferences would cap every run at 0.5
+        and make the task look unsolvable.
+        """
+        preferences = [
+            SoftPreference("early", ends_by("10:00")),
+            SoftPreference("late", starts_at_or_after("16:00")),
+        ]
+
+        result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert result.best_windows == ["08:00-09:00", "16:00-18:00"]
+
+    def test_tying_the_best_weight_reports_no_misses(self):
+        """Picking a different but equally good slot is not reported as a miss.
+
+        The earliest best slot honors "early" while the chosen one honors
+        "late". Both are optimal, so nothing was forgone.
+        """
+        preferences = [
+            SoftPreference("early", ends_by("10:00")),
+            SoftPreference("late", starts_at_or_after("16:00")),
+        ]
+
+        result = _score(_scheduled("16:00", "17:00"), soft_preferences=preferences)
+
+        assert result.soft_constraints_score == 1.0
+        assert result.satisfied_soft_constraints == ["late"]
+        assert result.missed_soft_constraints == []
+
+    def test_off_grid_optimum_is_found(self):
+        """The best slot is found even when it falls between two sweep steps.
+
+        The regular sweep only visits whole hours, and no whole hour satisfies
+        both preferences. Because each predicate declares its threshold, 09:30
+        is considered too, and it becomes the reference the booking is graded
+        against.
+        """
+        preferences = [
+            SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
+            SoftPreference("ends_by_ten_thirty", ends_by("10:30")),
+        ]
+
+        result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
+
+        assert result.best_windows == ["09:30"]
+        assert result.soft_constraints_score == 1.0
+        assert len(result.satisfied_soft_constraints) == 2
+
+    def test_on_grid_booking_is_graded_against_the_off_grid_optimum(self):
+        """A whole-hour booking does not get full marks when 09:30 was better.
+
+        This is the case a fixed hourly grid gets wrong: it would rate 09:00
+        the joint best and award 1.0, hiding the strictly better slot.
+        """
+        preferences = [
+            SoftPreference("starts_after_nine_thirty", starts_at_or_after("09:30")),
+            SoftPreference("ends_by_ten_thirty", ends_by("10:30")),
+        ]
+
+        result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 0.5
+        assert result.missed_soft_constraints == ["starts_after_nine_thirty"]
+
+    def test_slot_freed_by_a_commitment_ending_off_grid_is_considered(self):
+        """The moment an existing commitment ends is always a candidate."""
+        blocked = [_busy("08:00", "09:20")]
+        preferences = [SoftPreference("before_ten_twenty", ends_by("10:20"))]
+
+        result = _score(
+            _scheduled("10:30", "11:30"),
+            assistant_calendar=blocked,
+            soft_preferences=preferences,
+        )
+
+        assert result.feasible_windows == ["09:20-18:00"]
+        assert result.soft_constraints_score == 0.0
+
+    def test_half_hour_starts_are_considered_for_short_meetings(self):
+        """A 30-minute meeting can start on the half hour, so those slots count."""
+        result = score_task(
+            scheduled_meeting=_scheduled("08:30", "09:00"),
+            assistant_calendar=[],
+            requestor_calendar=[],
+            duration_minutes=30,
+            hard_constraints=[WORKING_DAY],
+            soft_preferences=[SoftPreference("after_eight_thirty", starts_at_or_after("08:30"))],
+        )
+
+        assert result.feasible_windows == ["08:00-18:30"]
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+
+    def test_feasible_slots_exclude_busy_and_forbidden_times(self):
+        """The reported slot list reflects both calendars and the hard constraints."""
+        result = _score(
+            _scheduled("13:00", "14:00"),
+            assistant_calendar=[_busy("08:00", "12:00")],
+            requestor_calendar=[_busy("15:00", "19:00")],
+            hard_constraints=[outside("12:00", "13:00")],
+        )
+
+        assert result.feasible_windows == ["13:00-14:00"]
+
+
+class TestPreferencesDefineTheDay:
+    """Bookable hours come from the task, never from a built-in working day."""
+
+    def test_a_late_night_slot_scores_full_marks_when_the_task_allows_it(self):
+        """A principal who only takes 22:00 meetings is served, not declined."""
+        result = score_task(
+            scheduled_meeting=_scheduled("22:00", "23:00"),
+            assistant_calendar=[],
+            requestor_calendar=[],
+            duration_minutes=DURATION,
+            hard_constraints=[within("22:00", "23:00")],
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_constraints_score == 1.0
+        assert result.feasible_windows == ["22:00"]

--- a/packages/srbench/tests/test_calendar_preference_scoring.py
+++ b/packages/srbench/tests/test_calendar_preference_scoring.py
@@ -73,7 +73,7 @@ class TestNothingScheduled:
         result = _score(None, hard_constraints=[ends_by("09:00"), starts_at_or_after("15:00")])
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
         assert result.feasible_windows == []
 
     def test_declining_is_wrong_when_a_slot_was_available(self):
@@ -81,7 +81,7 @@ class TestNothingScheduled:
         result = _score(None)
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert result.feasible_windows == ["08:00-18:00"]
 
     def test_busy_calendars_alone_can_make_a_task_infeasible(self):
@@ -91,7 +91,7 @@ class TestNothingScheduled:
         result = _score(None, assistant_calendar=blocked)
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
         assert result.feasible_windows == []
 
 
@@ -103,7 +103,7 @@ class TestScheduledButUnacceptable:
         result = _score(_scheduled("09:00", "10:00"), hard_constraints=[within("22:00", "23:00")])
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert result.chosen_slot == "09:00"
 
     def test_violating_a_hard_constraint_scores_zero(self):
@@ -111,7 +111,7 @@ class TestScheduledButUnacceptable:
         result = _score(_scheduled("15:00", "16:00"), hard_constraints=[outside("12:00", "16:00")])
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert "against a hard constraint" in result.explanation
 
     def test_double_booking_scores_zero(self):
@@ -119,14 +119,14 @@ class TestScheduledButUnacceptable:
         result = _score(_scheduled("09:00", "10:00"), requestor_calendar=[_busy("09:00", "10:00")])
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
 
     def test_wrong_duration_scores_zero(self):
         """A 30-minute booking does not satisfy a 60-minute request."""
         result = _score(_scheduled("09:00", "09:30"))
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert "30 minutes" in result.explanation
 
     def test_reported_conflicts_score_zero(self):
@@ -134,7 +134,7 @@ class TestScheduledButUnacceptable:
         result = _score(_scheduled("09:00", "10:00"), has_conflicts=True)
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert "conflict" in result.explanation
 
     def test_booking_outside_the_working_day_scores_zero(self):
@@ -142,7 +142,7 @@ class TestScheduledButUnacceptable:
         result = _score(_scheduled("20:00", "21:00"))
 
         assert not result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
         assert "against a hard constraint" in result.explanation
 
 
@@ -154,7 +154,7 @@ class TestSoftPreferenceScoring:
         result = _score(_scheduled("09:00", "10:00"))
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
 
     def test_best_slot_scores_full_marks(self):
         """Honoring every attainable preference scores 1.0."""
@@ -162,9 +162,9 @@ class TestSoftPreferenceScoring:
 
         result = _score(_scheduled("13:00", "14:00"), soft_preferences=preferences)
 
-        assert result.soft_constraints_score == 1.0
-        assert result.satisfied_soft_constraints == ["afternoon"]
-        assert result.missed_soft_constraints == []
+        assert result.soft_preferences_score == 1.0
+        assert result.satisfied_soft_preferences == ["afternoon"]
+        assert result.missed_soft_preferences == []
 
     def test_suboptimal_slot_scores_the_attained_fraction(self):
         """Meeting one of two attainable preferences scores 0.5."""
@@ -176,9 +176,9 @@ class TestSoftPreferenceScoring:
         result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.5
-        assert result.satisfied_soft_constraints == ["afternoon"]
-        assert result.missed_soft_constraints == ["before_five"]
+        assert result.soft_preferences_score == 0.5
+        assert result.satisfied_soft_preferences == ["afternoon"]
+        assert result.missed_soft_preferences == ["before_five"]
 
     def test_weights_scale_the_fraction(self):
         """A weight-3 preference is worth three times a weight-1 one."""
@@ -189,9 +189,9 @@ class TestSoftPreferenceScoring:
 
         result = _score(_scheduled("17:00", "18:00"), soft_preferences=preferences)
 
-        assert result.soft_constraints_score == 0.75
+        assert result.soft_preferences_score == 0.75
 
-    def test_unattainable_preferences_do_not_penalise(self):
+    def test_unattainable_preferences_do_not_penalize(self):
         """A preference no feasible slot can meet is excluded from the reference."""
         blocked = [_busy("08:00", "13:00")]
         preferences = [SoftPreference("morning", ends_by("12:00"))]
@@ -203,7 +203,7 @@ class TestSoftPreferenceScoring:
         )
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
 
     def test_conflicting_preferences_are_graded_against_the_best_slot(self):
         """Two preferences no slot can satisfy together still allow a perfect score.
@@ -219,7 +219,7 @@ class TestSoftPreferenceScoring:
 
         result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
 
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
         assert result.best_windows == ["08:00-09:00", "16:00-18:00"]
 
     def test_tying_the_best_weight_reports_no_misses(self):
@@ -235,9 +235,9 @@ class TestSoftPreferenceScoring:
 
         result = _score(_scheduled("16:00", "17:00"), soft_preferences=preferences)
 
-        assert result.soft_constraints_score == 1.0
-        assert result.satisfied_soft_constraints == ["late"]
-        assert result.missed_soft_constraints == []
+        assert result.soft_preferences_score == 1.0
+        assert result.satisfied_soft_preferences == ["late"]
+        assert result.missed_soft_preferences == []
 
     def test_off_grid_optimum_is_found(self):
         """The best slot is found even when it falls between two sweep steps.
@@ -255,8 +255,8 @@ class TestSoftPreferenceScoring:
         result = _score(_scheduled("09:30", "10:30"), soft_preferences=preferences)
 
         assert result.best_windows == ["09:30"]
-        assert result.soft_constraints_score == 1.0
-        assert len(result.satisfied_soft_constraints) == 2
+        assert result.soft_preferences_score == 1.0
+        assert len(result.satisfied_soft_preferences) == 2
 
     def test_on_grid_booking_is_graded_against_the_off_grid_optimum(self):
         """A whole-hour booking does not get full marks when 09:30 was better.
@@ -272,8 +272,8 @@ class TestSoftPreferenceScoring:
         result = _score(_scheduled("09:00", "10:00"), soft_preferences=preferences)
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 0.5
-        assert result.missed_soft_constraints == ["starts_after_nine_thirty"]
+        assert result.soft_preferences_score == 0.5
+        assert result.missed_soft_preferences == ["starts_after_nine_thirty"]
 
     def test_slot_freed_by_a_commitment_ending_off_grid_is_considered(self):
         """The moment an existing commitment ends is always a candidate."""
@@ -287,7 +287,7 @@ class TestSoftPreferenceScoring:
         )
 
         assert result.feasible_windows == ["09:20-18:00"]
-        assert result.soft_constraints_score == 0.0
+        assert result.soft_preferences_score == 0.0
 
     def test_half_hour_starts_are_considered_for_short_meetings(self):
         """A 30-minute meeting can start on the half hour, so those slots count."""
@@ -302,7 +302,7 @@ class TestSoftPreferenceScoring:
 
         assert result.feasible_windows == ["08:00-18:30"]
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
 
     def test_feasible_slots_exclude_busy_and_forbidden_times(self):
         """The reported slot list reflects both calendars and the hard constraints."""
@@ -330,5 +330,5 @@ class TestPreferencesDefineTheDay:
         )
 
         assert result.hard_constraints_satisfied
-        assert result.soft_constraints_score == 1.0
+        assert result.soft_preferences_score == 1.0
         assert result.feasible_windows == ["22:00"]

--- a/packages/srbench/tests/test_calendar_preference_scoring.py
+++ b/packages/srbench/tests/test_calendar_preference_scoring.py
@@ -114,13 +114,6 @@ class TestScheduledButUnacceptable:
         assert result.soft_preferences_score == 0.0
         assert "against a hard constraint" in result.explanation
 
-    def test_double_booking_scores_zero(self):
-        """Landing on a slot the requestor is busy for fails."""
-        result = _score(_scheduled("09:00", "10:00"), requestor_calendar=[_busy("09:00", "10:00")])
-
-        assert not result.hard_constraints_satisfied
-        assert result.soft_preferences_score == 0.0
-
     def test_wrong_duration_scores_zero(self):
         """A 30-minute booking does not satisfy a 60-minute request."""
         result = _score(_scheduled("09:00", "09:30"))
@@ -332,3 +325,84 @@ class TestPreferencesDefineTheDay:
         assert result.hard_constraints_satisfied
         assert result.soft_preferences_score == 1.0
         assert result.feasible_windows == ["22:00"]
+
+
+class TestRequestorCalendarOnlySetsTheBar:
+    """The assistant acts for its principal, so the requestor never blocks a slot.
+
+    The requestor's calendar decides what the soft score is measured against,
+    not what the assistant is allowed to pick. Both ways of playing it earn
+    full marks: taking the best slot free for everyone, and taking a better one
+    the requestor was busy for.
+    """
+
+    LATE = SoftPreference("late", starts_at_or_after("15:00"), weight=4.0)
+
+    def test_booking_over_a_requestor_meeting_is_allowed(self):
+        """A slot only the requestor is busy for still satisfies hard constraints."""
+        result = _score(_scheduled("09:00", "10:00"), requestor_calendar=[_busy("09:00", "10:00")])
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 1.0
+
+    def test_beating_the_best_shared_slot_is_clipped_to_one(self):
+        """Outscoring every slot free for both caps at 1 rather than exceeding it."""
+        result = _score(
+            _scheduled("15:00", "16:00"),
+            requestor_calendar=[_busy("15:00", "19:00")],
+            soft_preferences=[self.LATE],
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 1.0
+        assert result.feasible_windows == ["08:00-14:00"]
+        assert "requestor was busy" in result.explanation
+
+    def test_declining_to_book_over_the_requestor_is_not_penalized(self):
+        """Taking the best slot free for both is worth full marks, not a fraction."""
+        result = _score(
+            _scheduled("14:00", "15:00"),
+            requestor_calendar=[_busy("15:00", "19:00")],
+            soft_preferences=[self.LATE],
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 1.0
+
+    def test_a_worse_shared_slot_still_loses_marks(self):
+        """Clipping does not flatten the ranking among slots free for both."""
+        result = _score(
+            _scheduled("08:00", "09:00"),
+            soft_preferences=[self.LATE],
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 0.0
+        assert result.missed_soft_preferences == ["late"]
+
+    def test_declining_is_still_right_when_only_the_requestor_is_free(self):
+        """Not booking over the requestor is a valid choice, so it scores full marks."""
+        result = _score(None, requestor_calendar=[_busy("08:00", "19:00")])
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 1.0
+        assert result.feasible_windows == []
+
+    def test_booking_when_only_the_requestor_is_busy_all_day_scores_full_marks(self):
+        """With no shared slot there is no bar, so any bookable slot is the best one."""
+        result = _score(
+            _scheduled("15:00", "16:00"),
+            requestor_calendar=[_busy("08:00", "19:00")],
+            soft_preferences=[self.LATE],
+        )
+
+        assert result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 1.0
+        assert "no slot was free for the requestor too" in result.explanation
+
+    def test_the_principal_calendar_still_blocks(self):
+        """Only the requestor is disregarded; the principal's own calendar rules."""
+        result = _score(_scheduled("09:00", "10:00"), assistant_calendar=[_busy("09:00", "10:00")])
+
+        assert not result.hard_constraints_satisfied
+        assert result.soft_preferences_score == 0.0


### PR DESCRIPTION
## Goal

Turn the vocabulary from #48 into a score. Two numbers come out: whether the outcome broke an absolute rule, and how good the chosen slot was relative to what was reachable.

## Summary of changes

**`score_task` grades against the best achievable slot, not the sum of all preferences.** A slot is feasible if it is free on both calendars and passes every hard predicate; the score is the chosen slot's weight over the best feasible slot's weight. Dividing by the total of all stated preferences would cap a persona who prefers both early mornings and late batching at 0.5, however well the assistant did.

**Three outcomes.** No feasible slot: hard constraints are satisfied only by scheduling nothing, and declining scores 1.0. A feasible slot exists but the outcome violates a hard constraint: 0 and 0.0. Otherwise: chosen weight over best weight.

**`PreferenceAdherenceResult` reports the two numbers plus which preferences were met and missed,** so a failing run says what it gave up rather than only that it scored 0.4.

## How to test

```sh
uv run pytest packages/srbench/tests/test_calendar_preference_scoring.py
```

Tracked by #50.
