### PR TITLE
feat(calendar): allow the preference guidance block to be suppressed

### DIFF
--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/assistant/calendar_assistant.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/agents/assistant/calendar_assistant.py
@@ -40,6 +40,7 @@ class CalendarAssistantAgent(CalendarAgent):
         explicit_cot: bool = False,
         expose_preferences: bool = False,
         max_actions: int = 50,
+        preference_guidance: bool = True,
     ):
         super().__init__(
             model=model,
@@ -62,7 +63,9 @@ class CalendarAssistantAgent(CalendarAgent):
         preference_block = (
             format_user_preference_block(assistant.preference_md) if expose_preferences else ""
         )
-        guidance = CALENDAR_PREFERENCE_GUIDANCE if preference_block else None
+        guidance = (
+            CALENDAR_PREFERENCE_GUIDANCE if preference_block and preference_guidance else None
+        )
         sys_parts = [p for p in [base, identity, guidance] if p]
         self._messages.append({"role": "system", "content": "\n\n".join(sys_parts)})
 

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/benchmark.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/benchmark.py
@@ -139,6 +139,7 @@ class CalendarBenchmark(
             config.expose_preferences,
             cancel_event,
             benchmark_logger=self._benchmark_logger,
+            preference_guidance=config.preference_guidance,
         )
 
     def make_execution_error_result(

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/config.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/config.py
@@ -28,6 +28,9 @@ class CalendarRunConfig(BaseRunConfig):
 
     # Calendar-specific
     expose_preferences: bool = Field(default=True)
+    # When False, the <user_preference> block is still injected into the user
+    # turn but the system prompt gets no explanation of it. Ablation only.
+    preference_guidance: bool = Field(default=True)
 
     # --- Assistant resolved properties ---
 

--- a/packages/srbench/srbench/benchmarks/calendar_scheduling/executor.py
+++ b/packages/srbench/srbench/benchmarks/calendar_scheduling/executor.py
@@ -116,6 +116,7 @@ async def execute_task(
     expose_preferences: bool,
     cancel_event: asyncio.Event | None = None,
     benchmark_logger: BenchmarkLogger | None = None,
+    preference_guidance: bool = True,
 ) -> CalendarExecutionResult:
     """Execute a single calendar scheduling task.
 
@@ -216,6 +217,7 @@ async def execute_task(
         explicit_cot=assistant_explicit_cot,
         expose_preferences=expose_preferences,
         max_actions=max_actions_per_agent,
+        preference_guidance=preference_guidance,
     )
 
     requestor_agent = CalendarRequestorAgent(

--- a/packages/srbench/tests/test_calendar_preference_prompt.py
+++ b/packages/srbench/tests/test_calendar_preference_prompt.py
@@ -80,12 +80,17 @@ def _make_assistant(
     )
 
 
-def _messages(assistant: CalendarAssistant, expose_preferences: bool = True):
+def _messages(
+    assistant: CalendarAssistant,
+    expose_preferences: bool = True,
+    preference_guidance: bool = True,
+):
     """Build an assistant agent and return its seeded system and user messages.
 
     Args:
         assistant: The principal the agent acts for.
         expose_preferences: Whether preferences are shown to the model.
+        preference_guidance: Whether the system prompt explains the tag.
 
     Returns:
         A ``(system_content, user_content)`` tuple.
@@ -96,6 +101,7 @@ def _messages(assistant: CalendarAssistant, expose_preferences: bool = True):
         assistant=assistant,
         allowed_contacts=["bob@external.com"],
         expose_preferences=expose_preferences,
+        preference_guidance=preference_guidance,
     )
     system_message, user_message = agent.messages[0], agent.messages[1]
     return system_message["content"], user_message["content"]
@@ -138,6 +144,16 @@ class TestNaturalLanguagePreferences:
 
         assert CALENDAR_PREFERENCE_GUIDANCE in system
         assert system.startswith(CALENDAR_ROLE)
+
+    def test_guidance_can_be_suppressed_without_dropping_the_block(self):
+        """The ablation keeps the tagged block but leaves the system prompt bare."""
+        system, user = _messages(
+            _make_assistant(preference_md=PREFERENCE_MD), preference_guidance=False
+        )
+
+        assert CALENDAR_PREFERENCE_GUIDANCE not in system
+        assert f"<{USER_PREFERENCE_TAG}>" in user
+        assert "User never takes meetings during the noon hour." in user
 
     def test_system_prompt_defers_to_the_block_for_bookable_hours(self):
         """No working day is hard-coded; the preference block decides."""


### PR DESCRIPTION
Adds `preference_guidance` to `CalendarRunConfig` so the `CALENDAR_PREFERENCE_GUIDANCE`
system-prompt block can be suppressed independently of the `<user_preference>` block.

Without this, "does the model do better with a preference document?" and "does the
model do better with a system prompt explaining preference documents?" are the same
experiment, and the two effects cannot be separated. They turn out to point in
different directions, so the distinction matters.

```bash
--set preference_guidance=false
```

With the flag off, the assistant's system prompt is byte-identical (same sha256) to
the numeric arm's, while the `<user_preference>` block stays in the user turn. Default
is `True`, so nothing changes for any existing run.

Threaded the same way as `expose_preferences`: `config.py` → `benchmark.py` →
`executor.py` → `CalendarAssistantAgent`. 9 lines of production code plus a test.

Tracked by #50.
